### PR TITLE
Support reading commands from a file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -446,6 +446,7 @@ dependencies = [
  "hidapi",
  "lazy_static",
  "log",
+ "shellwords",
  "strong-xml",
  "termcolor 1.1.2",
  "thiserror",
@@ -686,6 +687,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "shellwords"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89e515aa4699a88148ed5ef96413ceef0048ce95b43fbc955a33bde0a70fcae6"
+dependencies = [
+ "lazy_static",
+ "regex",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ lazy_static = "1.4.0"
 atomic_refcell = "0.1.6"
 termcolor = "1.1.2"
 strong-xml = "0.6.0"
-
+shellwords = "1.1.0"
 
 [dependencies.hidapi]
 optional = true

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ FLAGS:
     -V, --version    Prints version information
 
 OPTIONS:
+    -f <file>          Read commands to run from the given filename
         --tcp <tcp>    The target address of the server component
         --usb <usb>...    The USB vendor and product id (2752:0011 for the 2x4HD)
 
@@ -118,6 +119,20 @@ PEQ 0: Applied imported filter: biquad1
 Warning: Some filters were not imported because they didn't fit (try using `all`)
 ```
 
+### Running multiple commands at once
+For the purposes of organizing configurations, a file can be created with commands to run sequentially.
+
+Files are using the same format at the command line, without the `minidsp` command.
+
+Example:
+```
+config 3
+input 0 peq all bypass off
+output 0 peq all bypass off
+mute off
+```
+
+> minidsp -f ./file.txt
 
 ### udev
 In order to run as a non-privileged user under Linux, you may have to add a udev rule for this specific device. Under `/etc/udev/rules.d`, create a file named `99-minidsp.rules` containing:

--- a/src/bin/minidsp/main.rs
+++ b/src/bin/minidsp/main.rs
@@ -34,7 +34,7 @@ struct Opts {
     /// The target address of the server component
     tcp_option: Option<String>,
 
-    #[clap(short='f')]
+    #[clap(short = 'f')]
     /// Read commands to run from the given filename
     file: Option<PathBuf>,
 

--- a/src/bin/minidsp/main.rs
+++ b/src/bin/minidsp/main.rs
@@ -324,8 +324,15 @@ async fn main() -> Result<()> {
             let words = shellwords::split(cmd)?;
             let prefix = &["minidsp".to_string()];
             let words = prefix.iter().chain(words.iter());
-            let opts = Opts::parse_from(words);
-            println!("Run: {:?}", opts);
+            let opts = Opts::try_parse_from(words);
+            let opts = match opts {
+                Ok(x) => x,
+                Err(e) => {
+                    eprintln!("While executing: {}\n{}", cmd, e);
+                    return Err(anyhow!("Command failure"));
+                }
+            };
+
             handlers::run_command(&device, opts.subcmd).await?;
         }
     } else {

--- a/src/bin/minidsp/main.rs
+++ b/src/bin/minidsp/main.rs
@@ -317,7 +317,7 @@ async fn main() -> Result<()> {
         let cmds = file.lines().filter(|s| {
             // Ignore comments and empty lines
             let trimmed = s.trim();
-            !trimmed.is_empty() && !trimmed.starts_with("#")
+            !trimmed.is_empty() && !trimmed.starts_with('#')
         });
 
         for cmd in cmds {

--- a/src/bin/minidsp/main.rs
+++ b/src/bin/minidsp/main.rs
@@ -34,6 +34,10 @@ struct Opts {
     /// The target address of the server component
     tcp_option: Option<String>,
 
+    #[clap(short='f')]
+    /// Read commands to run from the given filename
+    file: Option<PathBuf>,
+
     #[clap(subcommand)]
     subcmd: Option<SubCommand>,
 }
@@ -307,7 +311,26 @@ async fn main() -> Result<()> {
     let transport: Arc<dyn Transport> = get_transport(&opts).await?;
 
     let device = MiniDSP::new(transport, &device::DEVICE_2X4HD);
-    handlers::run_command(&device, opts.subcmd).await?;
+
+    if let Some(filename) = opts.file {
+        let file = std::fs::read_to_string(filename)?;
+        let cmds = file.lines().filter(|s| {
+            // Ignore comments and empty lines
+            let trimmed = s.trim();
+            !trimmed.is_empty() && !trimmed.starts_with("#")
+        });
+
+        for cmd in cmds {
+            let words = shellwords::split(cmd)?;
+            let prefix = &["minidsp".to_string()];
+            let words = prefix.iter().chain(words.iter());
+            let opts = Opts::parse_from(words);
+            println!("Run: {:?}", opts);
+            handlers::run_command(&device, opts.subcmd).await?;
+        }
+    } else {
+        handlers::run_command(&device, opts.subcmd).await?;
+    }
 
     Ok(())
 }


### PR DESCRIPTION
For the purposes of organizing configurations, a file can be created with commands to run sequentially.

Files are using the same format at the command line, without the `minidsp` command.

Example:
```
config 3
input 0 peq all bypass off
output 0 peq all bypass off
mute off
```

> minidsp -f ./file.txt

Closes #12 