### PR TITLE
Add FIR, Compressor and Xover support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -100,6 +100,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bimap"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f92b72b8f03128773278bf74418b9205f3d2a12c39a61f92395f47af390c32bf"
+
+[[package]]
 name = "bitflags"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -434,6 +440,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "atomic_refcell",
+ "bimap",
  "bytes",
  "clap",
  "enum-utils",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,6 +31,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68803225a7b13e47191bab76f2687382b60d259e8cf37f6e1893658b84bb9479"
 
 [[package]]
+name = "assert_approx_eq"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c07dab4369547dbe5114677b33fbbf724971019f3818172d59a97a61c774ffd"
+
+[[package]]
 name = "async-stream"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -437,6 +443,7 @@ name = "minidsp"
 version = "0.0.2-dev"
 dependencies = [
  "anyhow",
+ "assert_approx_eq",
  "async-stream",
  "async-trait",
  "atomic_refcell",
@@ -460,6 +467,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tokio-util",
+ "wav",
 ]
 
 [[package]]
@@ -672,6 +680,12 @@ name = "regex-syntax"
 version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b181ba2dcf07aaccad5448e8ead58db5b742cf85dfe035e2227f137a539a189"
+
+[[package]]
+name = "riff"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9b1a3d5f46d53f4a3478e2be4a5a5ce5108ea58b100dcd139830eae7f79a3a1"
 
 [[package]]
 name = "rustc-demangle"
@@ -924,6 +938,15 @@ name = "version_check"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed"
+
+[[package]]
+name = "wav"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f57d7ddfab03e51496696ce01738f9b22372fa62da563b236e694e8ac6afa51"
+dependencies = [
+ "riff",
+]
 
 [[package]]
 name = "winapi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,10 @@ termcolor = "1.1.2"
 strong-xml = "0.6.0"
 shellwords = "1.1.0"
 bimap = "0.6.0"
+wav = "0.5.0"
+
+[dev-dependencies]
+assert_approx_eq = "1.1.0"
 
 [dependencies.hidapi]
 optional = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,5 +72,6 @@ Provides a way to control a MiniDSP 2x4HD and other compatible variants from the
 assets = [
     ["target/release/minidsp", "usr/bin/", "755"],
     ["README.md", "usr/share/doc/minidsp/README", "644"],
-    ["debian/minidsp.service","lib/systemd/system/minidsp.service", "644"]
+    ["debian/minidsp.service","lib/systemd/system/minidsp.service", "644"],
+    ["debian/minidsp.udev","lib/udev/rules.d/99-minidsp.rules", "644"]
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ atomic_refcell = "0.1.6"
 termcolor = "1.1.2"
 strong-xml = "0.6.0"
 shellwords = "1.1.0"
+bimap = "0.6.0"
 
 [dependencies.hidapi]
 optional = true

--- a/README.md
+++ b/README.md
@@ -12,6 +12,15 @@ Debian packages are available for:
 - armhf: Tested on raspbian (Raspberry PI, including the rpi0)
 - x86_64 Debian / Ubuntu variants
 
+Tip: the packages do not automatically enable the server component, if you want to be able to use this app or the official plugin from another machine, enable the service with:
+
+```shell
+systemctl enable minidsp.service
+systemctl start minidsp.service
+```
+
+You can then connect with `minidsp --tcp=ip:5333 ` (or set the `MINIDSP_TCP` env var) or with the official plugin.
+
 Single binary distribution are also provided for common operating systems:
 - Linux: minidsp.x86_64-unknown-linux-gnu.tar.gz
 - MacOS: minidsp.x86_64-apple-darwin.tar.gz

--- a/README.md
+++ b/README.md
@@ -277,8 +277,11 @@ Crossovers are implemented as series biquad filters. There are two groups of 4 b
 The command follows the same syntax as the `peq` command, for the exception that you have to specify the group index.
 
 They can be imported in REW's format:
-`minidsp output 0 crossover 0 all import ./file.txt`
-`minidsp output 0 crossover 1 all import ./file2.txt`
+
+```shell
+minidsp output 0 crossover 0 all import ./file.txt
+minidsp output 0 crossover 1 all import ./file2.txt
+```
 
 ### FIR
 
@@ -300,8 +303,10 @@ SUBCOMMANDS:
 
 Importing FIR filters can be done using a wav file. The file's sampling rate MUST match the device's internal rate. 
 
-`minidsp output 0 fir import ./impulse.wav`
-`minidsp output 0 fir bypass off`
+```shell
+minidsp output 0 fir import ./impulse.wav
+minidsp output 0 fir bypass off
+```
 
 ### Delay
 

--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ This is where you'd configure routing, gain settings and PEQ for each input
 
 <details>
   <summary>(Click to expand) minidsp input [input-index] [SUBCOMMAND]</summary>
+
 ```shell
 $ minidsp input --help
 minidsp-input
@@ -116,6 +117,7 @@ SUBCOMMANDS:
 ```
 
 #### gain / mute
+
 ```shell
 # Sets input channel 0's gain to -10dB
 minidsp input 0 gain -- -10
@@ -133,6 +135,7 @@ minidsp input 0 routing 0 gain 6
 ```
 
 #### peq
+
 ```
 $ minidsp input 0 peq --help
 minidsp-input-peq
@@ -201,6 +204,7 @@ SUBCOMMANDS:
 ```
 
 #### Gain
+
 ```shell
 $ minidsp output 0 gain --help
 USAGE:
@@ -247,6 +251,7 @@ Importing filters should use the `all` target if the ununsed filter should also 
 `minidsp output 0 preq all import ./file.txt`
 
 #### Crossover
+
 ```
 $ minidsp output 0 crossover --help
 Controls crossovers (2x 4 biquads)
@@ -275,6 +280,7 @@ They can be imported in REW's format:
 `minidsp output 0 crossover 1 all import ./file2.txt`
 
 #### FIR
+
 ```shell
 $ minidsp output 0 fir --help
 minidsp-output-fir
@@ -297,6 +303,7 @@ Importing FIR filters can be done using a wav file. The file's sampling rate MUS
 `minidsp output 0 fir bypass off`
 
 #### Delay
+
 ```shell
 $ minidsp output 0 delay --help
 minidsp-output-delay
@@ -310,6 +317,7 @@ ARGS:
 ```
 
 #### Invert
+
 ```
 USAGE:
     minidsp output <output-index> invert <value>

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ SUBCOMMANDS:
     routing    Controls signal routing from this input
 ```
 
-#### gain / mute
+### gain / mute
 
 ```shell
 # Sets input channel 0's gain to -10dB
@@ -125,7 +125,8 @@ minidsp input 0 gain -- -10
 # Mute input channel 0
 minidsp input 0 mute on
 ```
-#### routing
+
+### routing
 Each output matrix entry has to be enabled in order for audio to be routed. The gain can then be set (in dB) for each entry.
 
 ```shell
@@ -134,7 +135,7 @@ minidsp input 0 routing 0 enable on
 minidsp input 0 routing 0 gain 6
 ```
 
-#### peq
+### peq
 
 ```
 $ minidsp input 0 peq --help
@@ -203,7 +204,7 @@ SUBCOMMANDS:
     peq           Control the parametric equalizer
 ```
 
-#### Gain
+### Gain
 
 ```shell
 $ minidsp output 0 gain --help
@@ -218,7 +219,7 @@ Example usage: `minidsp output 0 gain -- -20`
 
 `--` is used to distinguish negative values from another option
 
-#### PEQ
+### PEQ
 
 ```
 $ minidsp output 0 peq --help
@@ -250,7 +251,7 @@ Bypass all peqs:
 Importing filters should use the `all` target if the ununsed filter should also be cleared.
 `minidsp output 0 preq all import ./file.txt`
 
-#### Crossover
+### Crossover
 
 ```
 $ minidsp output 0 crossover --help
@@ -279,7 +280,7 @@ They can be imported in REW's format:
 `minidsp output 0 crossover 0 all import ./file.txt`
 `minidsp output 0 crossover 1 all import ./file2.txt`
 
-#### FIR
+### FIR
 
 ```shell
 $ minidsp output 0 fir --help
@@ -302,7 +303,7 @@ Importing FIR filters can be done using a wav file. The file's sampling rate MUS
 `minidsp output 0 fir import ./impulse.wav`
 `minidsp output 0 fir bypass off`
 
-#### Delay
+### Delay
 
 ```shell
 $ minidsp output 0 delay --help
@@ -316,7 +317,7 @@ ARGS:
     <delay>    Delay in milliseconds
 ```
 
-#### Invert
+### Invert
 
 ```
 USAGE:

--- a/debian/minidsp.udev
+++ b/debian/minidsp.udev
@@ -1,0 +1,1 @@
+ATTR{idVendor}=="2752", MODE="660", GROUP="plugdev"

--- a/debian/postinst
+++ b/debian/postinst
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+#DEBHELPER#
+
+/usr/bin/udevadm control --reload-rules

--- a/src/bin/decode/main.rs
+++ b/src/bin/decode/main.rs
@@ -94,10 +94,7 @@ async fn decode(framed: impl Stream<Item = recorder::Message>) -> Result<()> {
     let mut decoder = {
         use termcolor::{ColorChoice, StandardStream};
         let writer = StandardStream::stdout(ColorChoice::Always);
-        decoder::Decoder {
-            w: Box::new(writer),
-            quiet: true,
-        }
+        decoder::Decoder::new(Box::new(writer), true)
     };
 
     let mut n_recv: i32 = 0;

--- a/src/bin/minidsp/handlers.rs
+++ b/src/bin/minidsp/handlers.rs
@@ -121,6 +121,30 @@ pub(crate) async fn run_output(
         OutputCommand::Crossover { group, index, cmd } => {
             run_xover(&output.crossover(), cmd, group, index).await?
         }
+        OutputCommand::Compressor {
+            bypass,
+            threshold,
+            ratio,
+            attack,
+            release,
+        } => {
+            let compressor = output.compressor();
+            if let Some(bypass) = bypass {
+                compressor.set_bypass(bypass).await?;
+            }
+            if let Some(threshold) = threshold {
+                compressor.set_threshold(threshold).await?;
+            }
+            if let Some(ratio) = ratio {
+                compressor.set_ratio(ratio).await?;
+            }
+            if let Some(attack) = attack {
+                compressor.set_attack(attack).await?;
+            }
+            if let Some(release) = release {
+                compressor.set_release(release).await?;
+            }
+        }
     }
     Ok(())
 }

--- a/src/bin/minidsp/main.rs
+++ b/src/bin/minidsp/main.rs
@@ -10,7 +10,14 @@ use minidsp::{
     transport::{net::NetTransport, Transport},
     Gain, MiniDSP,
 };
-use std::{fs::File, io::{BufRead, BufReader}, num::ParseIntError, path::PathBuf, str::FromStr, sync::Arc};
+use std::{
+    fs::File,
+    io::{BufRead, BufReader},
+    num::ParseIntError,
+    path::PathBuf,
+    str::FromStr,
+    sync::Arc,
+};
 use tokio::net::TcpStream;
 
 mod debug;
@@ -19,9 +26,9 @@ mod handlers;
 #[cfg(feature = "hid")]
 use minidsp::transport::hid;
 use minidsp::transport::Openable;
+use std::io::Read;
 use std::ops::Deref;
 use std::time::Duration;
-use std::io::Read;
 
 #[derive(Clap, Debug)]
 #[clap(version=env!("CARGO_PKG_VERSION"), author=env!("CARGO_PKG_AUTHORS"))]

--- a/src/bin/minidsp/main.rs
+++ b/src/bin/minidsp/main.rs
@@ -130,7 +130,7 @@ enum InputCommand {
         index: PEQTarget,
 
         #[clap(subcommand)]
-        cmd: PEQCommand,
+        cmd: FilterCommand,
     },
 }
 
@@ -180,8 +180,26 @@ enum OutputCommand {
         index: PEQTarget,
 
         #[clap(subcommand)]
-        cmd: PEQCommand,
+        cmd: FilterCommand,
     },
+
+    /// Controls the FIR filter
+    FIR {
+        #[clap(subcommand)]
+        cmd: FilterCommand,
+    },
+
+    /// Controls crossovers (2x 4 biquads)
+    Crossover {
+        /// Group index (0 or 1)
+        group: usize,
+
+        /// Filter index (all | 0 | 1 | 3)
+        index: PEQTarget,
+
+        #[clap(subcommand)]
+        cmd: FilterCommand,
+    }
 }
 
 #[derive(Debug)]
@@ -203,10 +221,10 @@ impl FromStr for PEQTarget {
 }
 
 #[derive(Clap, Debug)]
-enum PEQCommand {
-    /// Set biquad coefficients
+enum FilterCommand {
+    /// Set coefficients
     Set {
-        /// Biquad coefficients
+        /// Coefficients
         coeff: Vec<f32>,
     },
 
@@ -223,6 +241,8 @@ enum PEQCommand {
     Import {
         /// Filename containing the coefficients in REW format
         filename: PathBuf,
+        /// Import file format
+        format: Option<String>,
     },
 }
 

--- a/src/bin/minidsp/main.rs
+++ b/src/bin/minidsp/main.rs
@@ -43,7 +43,7 @@ struct Opts {
     tcp_option: Option<String>,
 
     #[clap(short = 'f')]
-    /// Read commands to run from the given filename
+    /// Read commands to run from the given filename (use - for stdin)
     file: Option<PathBuf>,
 
     #[clap(subcommand)]
@@ -203,7 +203,7 @@ enum OutputCommand {
 
     /// Controls crossovers (2x 4 biquads)
     Compressor {
-        /// Bypass the compressor
+        /// Bypasses the compressor (on | off)
         #[clap(short='b', long, parse(try_from_str = on_or_off))]
         bypass: Option<bool>,
 

--- a/src/bin/minidsp/main.rs
+++ b/src/bin/minidsp/main.rs
@@ -199,7 +199,30 @@ enum OutputCommand {
 
         #[clap(subcommand)]
         cmd: FilterCommand,
-    }
+    },
+
+    /// Controls crossovers (2x 4 biquads)
+    Compressor {
+        /// Bypass the compressor
+        #[clap(short='b', long, parse(try_from_str = on_or_off))]
+        bypass: Option<bool>,
+
+        /// Sets the threshold in dBFS
+        #[clap(short = 't', long)]
+        threshold: Option<f32>,
+
+        /// Sets the ratio
+        #[clap(short = 'k', long)]
+        ratio: Option<f32>,
+
+        /// Sets the attack time in ms
+        #[clap(short = 'a', long)]
+        attack: Option<f32>,
+
+        /// Sets the release time in ms
+        #[clap(short = 'r', long)]
+        release: Option<f32>,
+    },
 }
 
 #[derive(Debug)]

--- a/src/bin/minidsp/main.rs
+++ b/src/bin/minidsp/main.rs
@@ -150,7 +150,7 @@ enum RoutingCommand {
 
 #[derive(Clap, Debug)]
 enum OutputCommand {
-    /// Set the input gain for this channel
+    /// Set the output gain for this channel
     Gain {
         /// Output gain in dB
         value: Gain,
@@ -183,13 +183,13 @@ enum OutputCommand {
         cmd: FilterCommand,
     },
 
-    /// Controls the FIR filter
+    /// Control the FIR filter
     FIR {
         #[clap(subcommand)]
         cmd: FilterCommand,
     },
 
-    /// Controls crossovers (2x 4 biquads)
+    /// Control crossovers (2x 4 biquads)
     Crossover {
         /// Group index (0 or 1)
         group: usize,
@@ -201,7 +201,7 @@ enum OutputCommand {
         cmd: FilterCommand,
     },
 
-    /// Controls crossovers (2x 4 biquads)
+    /// Control the compressor
     Compressor {
         /// Bypasses the compressor (on | off)
         #[clap(short='b', long, parse(try_from_str = on_or_off))]

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -500,6 +500,13 @@ impl Responses {
             _ => Err(MiniDSPError::MalformedResponse),
         }
     }
+
+    pub fn into_fir_size(self) -> Result<u16, MiniDSPError> {
+        match self {
+            Responses::FirLoadSize { size } => Ok(size),
+            _ => Err(MiniDSPError::MalformedResponse),
+        }
+    }
 }
 
 /// Parsable response type

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,5 @@
 //! Utilities for dealing with xml configuration files
+use bimap::BiMap;
 use bytes::Bytes;
 use std::fmt;
 use std::fmt::{Display, Formatter};
@@ -90,6 +91,27 @@ impl Setting {
                 para[0].subpara.sort_unstable_by_key(|sp| sp.row);
             }
         }
+    }
+
+    /// Returns a BiMap with all names and indices inside this config
+    pub fn name_map(&self) -> BiMap<String, usize> {
+        let mut map = BiMap::<String, usize>::new();
+
+        for item in &self.items {
+            match item {
+                AddressableElement::Item { name, addr, .. } => {
+                    map.insert(name.clone(), *addr as usize);
+                }
+                AddressableElement::Fir { name, addr, .. } => {
+                    map.insert(name.clone(), *addr as usize);
+                }
+                AddressableElement::Filter { name, addr, .. } => {
+                    map.insert(name.clone(), *addr as usize);
+                }
+            }
+        }
+
+        map
     }
 }
 

--- a/src/device.rs
+++ b/src/device.rs
@@ -78,7 +78,16 @@ pub const DEVICE_2X4HD: Device = Device {
                 len: 10,
             },
             xover: Crossover {
-                peqs: [PEQ { high: 0x2193, len: 4 }, PEQ { high: 0x21a7, len: 4 }],
+                peqs: [
+                    PEQ {
+                        high: 0x2193,
+                        len: 4,
+                    },
+                    PEQ {
+                        high: 0x21a7,
+                        len: 4,
+                    },
+                ],
                 bypass: [0x2184, 0x2198],
             },
             compressor: Compressor {
@@ -88,8 +97,11 @@ pub const DEVICE_2X4HD: Device = Device {
                 attack: 0x2c,
                 release: 0x2d,
             },
-            fir_bypass_addr: 0x0e,
-            fir_index: 0,
+            fir: Fir {
+                index: 0,
+                bypass: 0xe,
+                num_coefficients: 0x54,
+            },
         },
         Output {
             gate: Gate {
@@ -103,7 +115,16 @@ pub const DEVICE_2X4HD: Device = Device {
                 len: 10,
             },
             xover: Crossover {
-                peqs: [PEQ { high: 0x21bb, len: 4 }, PEQ { high: 0x21cf, len: 4 }],
+                peqs: [
+                    PEQ {
+                        high: 0x21bb,
+                        len: 4,
+                    },
+                    PEQ {
+                        high: 0x21cf,
+                        len: 4,
+                    },
+                ],
                 bypass: [0x21ac, 0x21c0],
             },
             compressor: Compressor {
@@ -113,8 +134,11 @@ pub const DEVICE_2X4HD: Device = Device {
                 attack: 0x32,
                 release: 0x33,
             },
-            fir_bypass_addr: 0x0f,
-            fir_index: 1,
+            fir: Fir {
+                index: 1,
+                bypass: 0xf,
+                num_coefficients: 0x855,
+            },
         },
         Output {
             gate: Gate {
@@ -128,7 +152,16 @@ pub const DEVICE_2X4HD: Device = Device {
                 len: 10,
             },
             xover: Crossover {
-                peqs: [PEQ { high: 0x21e3, len: 4 }, PEQ { high: 0x21f7, len: 4 }],
+                peqs: [
+                    PEQ {
+                        high: 0x21e3,
+                        len: 4,
+                    },
+                    PEQ {
+                        high: 0x21f7,
+                        len: 4,
+                    },
+                ],
                 bypass: [0x21e8, 0x21d4],
             },
             compressor: Compressor {
@@ -138,8 +171,11 @@ pub const DEVICE_2X4HD: Device = Device {
                 attack: 0x38,
                 release: 0x39,
             },
-            fir_bypass_addr: 0x10,
-            fir_index: 2,
+            fir: Fir {
+                index: 2,
+                bypass: 0x10,
+                num_coefficients: 0x1056,
+            },
         },
         Output {
             gate: Gate {
@@ -153,7 +189,16 @@ pub const DEVICE_2X4HD: Device = Device {
                 len: 10,
             },
             xover: Crossover {
-                peqs: [PEQ { high: 0x220b, len: 4 }, PEQ { high: 0x221f, len: 4 }],
+                peqs: [
+                    PEQ {
+                        high: 0x220b,
+                        len: 4,
+                    },
+                    PEQ {
+                        high: 0x221f,
+                        len: 4,
+                    },
+                ],
                 bypass: [0x21fc, 0x2210],
             },
             compressor: Compressor {
@@ -163,8 +208,11 @@ pub const DEVICE_2X4HD: Device = Device {
                 attack: 0x3e,
                 release: 0x3f,
             },
-            fir_bypass_addr: 0x11,
-            fir_index: 3,
+            fir: Fir {
+                index: 3,
+                bypass: 0x11,
+                num_coefficients: 0x1857,
+            },
         },
     ],
 };
@@ -208,9 +256,7 @@ pub struct Output {
     pub compressor: Compressor,
     // XXX: TODO: active=2 bypass=3 via 0x13 0x80
     /// Address of the FIR bypass toggle
-    pub fir_bypass_addr: u16,
-    /// Index to use when sending FIR load commands
-    pub fir_index: u8,
+    pub fir: Fir,
 }
 
 /// Reference to a control having both a mute and gain setting
@@ -265,6 +311,18 @@ pub struct Crossover {
 
     /// Bypass addresses. Contrary to regular PEQs, there are 2 bypass addresses for 8 biquads.
     pub bypass: [u16; 2],
+}
+
+#[derive(Debug)]
+pub struct Fir {
+    /// Index to use in the FIRLoad commands
+    pub index: u8,
+
+    /// Address saving the number of active coefficients
+    pub num_coefficients: u16,
+
+    /// Bypass address
+    pub bypass: u16,
 }
 
 #[cfg(test)]

--- a/src/device.rs
+++ b/src/device.rs
@@ -77,12 +77,16 @@ pub const DEVICE_2X4HD: Device = Device {
                 high: 0x20e9,
                 len: 10,
             },
-            xover: [PEQ { high: 0, len: 0 }, PEQ { high: 0, len: 0 }],
+            xover: Crossover {
+                peqs: [PEQ { high: 0x2193, len: 4 }, PEQ { high: 0x21a7, len: 4 }],
+                bypass: [0x2184, 0x2198],
+            },
             compressor: Compressor {
-                threshold: 0,
-                ratio: 0,
-                attack: 0,
-                release: 0,
+                bypass: 0x16,
+                threshold: 0x28,
+                ratio: 0x2a,
+                attack: 0x2c,
+                release: 0x2d,
             },
             fir_bypass_addr: 0x0e,
             fir_index: 0,
@@ -98,12 +102,16 @@ pub const DEVICE_2X4HD: Device = Device {
                 high: 0x211b,
                 len: 10,
             },
-            xover: [PEQ { high: 0, len: 0 }, PEQ { high: 0, len: 0 }],
+            xover: Crossover {
+                peqs: [PEQ { high: 0x21bb, len: 4 }, PEQ { high: 0x21cf, len: 4 }],
+                bypass: [0x21ac, 0x21c0],
+            },
             compressor: Compressor {
-                threshold: 0,
-                ratio: 0,
-                attack: 0,
-                release: 0,
+                bypass: 0x17,
+                threshold: 0x2e,
+                ratio: 0x30,
+                attack: 0x32,
+                release: 0x33,
             },
             fir_bypass_addr: 0x0f,
             fir_index: 1,
@@ -119,12 +127,16 @@ pub const DEVICE_2X4HD: Device = Device {
                 high: 0x214d,
                 len: 10,
             },
-            xover: [PEQ { high: 0, len: 0 }, PEQ { high: 0, len: 0 }],
+            xover: Crossover {
+                peqs: [PEQ { high: 0x21e3, len: 4 }, PEQ { high: 0x21f7, len: 4 }],
+                bypass: [0x21e8, 0x21d4],
+            },
             compressor: Compressor {
-                threshold: 0,
-                ratio: 0,
-                attack: 0,
-                release: 0,
+                bypass: 0x18,
+                threshold: 0x34,
+                ratio: 0x36,
+                attack: 0x38,
+                release: 0x39,
             },
             fir_bypass_addr: 0x10,
             fir_index: 2,
@@ -140,12 +152,16 @@ pub const DEVICE_2X4HD: Device = Device {
                 high: 0x217f,
                 len: 10,
             },
-            xover: [PEQ { high: 0, len: 0 }, PEQ { high: 0, len: 0 }],
+            xover: Crossover {
+                peqs: [PEQ { high: 0x220b, len: 4 }, PEQ { high: 0x221f, len: 4 }],
+                bypass: [0x21fc, 0x2210],
+            },
             compressor: Compressor {
-                threshold: 0,
-                ratio: 0,
-                attack: 0,
-                release: 0,
+                bypass: 0x19,
+                threshold: 0x3a,
+                ratio: 0x3c,
+                attack: 0x3e,
+                release: 0x3f,
             },
             fir_bypass_addr: 0x11,
             fir_index: 3,
@@ -154,6 +170,7 @@ pub const DEVICE_2X4HD: Device = Device {
 };
 
 /// Defines how the high level api should interact with the device based on its memory layout
+#[derive(Debug)]
 pub struct Device {
     /// The name of the input sources
     pub sources: &'static [Source],
@@ -164,6 +181,7 @@ pub struct Device {
 }
 
 /// Defines an input channel and its features
+#[derive(Debug)]
 pub struct Input {
     /// Mute and Gain
     pub gate: Gate,
@@ -174,6 +192,7 @@ pub struct Input {
 }
 
 /// Defines an output channel and its features
+#[derive(Debug)]
 pub struct Output {
     /// Mute and Gain
     pub gate: Gate,
@@ -184,7 +203,7 @@ pub struct Output {
     /// Parametric equalizers
     pub peq: PEQ,
     /// Crossover biquads
-    pub xover: [PEQ; 2],
+    pub xover: Crossover,
     /// Compressor
     pub compressor: Compressor,
     // XXX: TODO: active=2 bypass=3 via 0x13 0x80
@@ -195,6 +214,7 @@ pub struct Output {
 }
 
 /// Reference to a control having both a mute and gain setting
+#[derive(Debug)]
 pub struct Gate {
     /// Address controlling whether audio is enabled, 1 = off 2 = on
     pub enable: u16,
@@ -202,15 +222,17 @@ pub struct Gate {
     /// Address where the gain is controlled
     pub gain: u16,
 }
-
+#[derive(Debug)]
 pub struct Compressor {
+    pub bypass: u16,
     pub threshold: u16,
     pub ratio: u16,
     pub attack: u16,
     pub release: u16,
 }
 
-/// A range of biquad filter address part of a single parametric eq
+/// A range of contiguous biquad filter addresses
+#[derive(Debug)]
 pub struct PEQ {
     /// Higher bound address
     pub high: u16,
@@ -234,6 +256,15 @@ impl PEQ {
     pub fn iter(&'_ self) -> impl '_ + Iterator<Item = u16> {
         (0..self.len).map(move |x| self.at(x))
     }
+}
+
+#[derive(Debug)]
+pub struct Crossover {
+    /// Individual biquad groups. On the 2x4HD there are two of these containing 4 biquads each.
+    pub peqs: [PEQ; 2],
+
+    /// Bypass addresses. Contrary to regular PEQs, there are 2 bypass addresses for 8 biquads.
+    pub bypass: [u16; 2],
 }
 
 #[cfg(test)]

--- a/src/device.rs
+++ b/src/device.rs
@@ -77,7 +77,15 @@ pub const DEVICE_2X4HD: Device = Device {
                 high: 0x20e9,
                 len: 10,
             },
+            xover: [PEQ { high: 0, len: 0 }, PEQ { high: 0, len: 0 }],
+            compressor: Compressor {
+                threshold: 0,
+                ratio: 0,
+                attack: 0,
+                release: 0,
+            },
             fir_bypass_addr: 0x0e,
+            fir_index: 0,
         },
         Output {
             gate: Gate {
@@ -90,7 +98,15 @@ pub const DEVICE_2X4HD: Device = Device {
                 high: 0x211b,
                 len: 10,
             },
+            xover: [PEQ { high: 0, len: 0 }, PEQ { high: 0, len: 0 }],
+            compressor: Compressor {
+                threshold: 0,
+                ratio: 0,
+                attack: 0,
+                release: 0,
+            },
             fir_bypass_addr: 0x0f,
+            fir_index: 1,
         },
         Output {
             gate: Gate {
@@ -103,7 +119,15 @@ pub const DEVICE_2X4HD: Device = Device {
                 high: 0x214d,
                 len: 10,
             },
+            xover: [PEQ { high: 0, len: 0 }, PEQ { high: 0, len: 0 }],
+            compressor: Compressor {
+                threshold: 0,
+                ratio: 0,
+                attack: 0,
+                release: 0,
+            },
             fir_bypass_addr: 0x10,
+            fir_index: 2,
         },
         Output {
             gate: Gate {
@@ -116,7 +140,15 @@ pub const DEVICE_2X4HD: Device = Device {
                 high: 0x217f,
                 len: 10,
             },
+            xover: [PEQ { high: 0, len: 0 }, PEQ { high: 0, len: 0 }],
+            compressor: Compressor {
+                threshold: 0,
+                ratio: 0,
+                attack: 0,
+                release: 0,
+            },
             fir_bypass_addr: 0x11,
+            fir_index: 3,
         },
     ],
 };
@@ -151,12 +183,15 @@ pub struct Output {
     pub invert_addr: u16,
     /// Parametric equalizers
     pub peq: PEQ,
-    // TODO: Xover
-    // TODO: Compressor
-    // pub fir_coeff_addr: u16,
+    /// Crossover biquads
+    pub xover: [PEQ; 2],
+    /// Compressor
+    pub compressor: Compressor,
     // XXX: TODO: active=2 bypass=3 via 0x13 0x80
     /// Address of the FIR bypass toggle
     pub fir_bypass_addr: u16,
+    /// Index to use when sending FIR load commands
+    pub fir_index: u8,
 }
 
 /// Reference to a control having both a mute and gain setting
@@ -166,6 +201,13 @@ pub struct Gate {
 
     /// Address where the gain is controlled
     pub gain: u16,
+}
+
+pub struct Compressor {
+    pub threshold: u16,
+    pub ratio: u16,
+    pub attack: u16,
+    pub release: u16,
 }
 
 /// A range of biquad filter address part of a single parametric eq

--- a/src/device.rs
+++ b/src/device.rs
@@ -101,6 +101,7 @@ pub const DEVICE_2X4HD: Device = Device {
                 index: 0,
                 bypass: 0xe,
                 num_coefficients: 0x54,
+                max_coefficients: 2048,
             },
         },
         Output {
@@ -138,6 +139,7 @@ pub const DEVICE_2X4HD: Device = Device {
                 index: 1,
                 bypass: 0xf,
                 num_coefficients: 0x855,
+                max_coefficients: 2048,
             },
         },
         Output {
@@ -175,6 +177,7 @@ pub const DEVICE_2X4HD: Device = Device {
                 index: 2,
                 bypass: 0x10,
                 num_coefficients: 0x1056,
+                max_coefficients: 2048,
             },
         },
         Output {
@@ -212,9 +215,12 @@ pub const DEVICE_2X4HD: Device = Device {
                 index: 3,
                 bypass: 0x11,
                 num_coefficients: 0x1857,
+                max_coefficients: 2048,
             },
         },
     ],
+    fir_max_taps: 4096,
+    internal_sampling_rate: 96000,
 };
 
 /// Defines how the high level api should interact with the device based on its memory layout
@@ -226,6 +232,10 @@ pub struct Device {
     pub inputs: &'static [Input],
     /// The definitions for all output channels
     pub outputs: &'static [Output],
+    /// Maximum total number of FIR taps
+    pub fir_max_taps: u16,
+    /// Internal sampling rate in Hz
+    pub internal_sampling_rate: u32,
 }
 
 /// Defines an input channel and its features
@@ -323,6 +333,9 @@ pub struct Fir {
 
     /// Bypass address
     pub bypass: u16,
+
+    /// Maximum supported coefficients
+    pub max_coefficients: u16,
 }
 
 #[cfg(test)]

--- a/src/device.rs
+++ b/src/device.rs
@@ -96,6 +96,7 @@ pub const DEVICE_2X4HD: Device = Device {
                 ratio: 0x2a,
                 attack: 0x2c,
                 release: 0x2d,
+                meter: 0x46,
             },
             fir: Fir {
                 index: 0,
@@ -134,6 +135,7 @@ pub const DEVICE_2X4HD: Device = Device {
                 ratio: 0x30,
                 attack: 0x32,
                 release: 0x33,
+                meter: 0x47,
             },
             fir: Fir {
                 index: 1,
@@ -172,6 +174,7 @@ pub const DEVICE_2X4HD: Device = Device {
                 ratio: 0x36,
                 attack: 0x38,
                 release: 0x39,
+                meter: 0x48,
             },
             fir: Fir {
                 index: 2,
@@ -210,6 +213,7 @@ pub const DEVICE_2X4HD: Device = Device {
                 ratio: 0x3c,
                 attack: 0x3e,
                 release: 0x3f,
+                meter: 0x49,
             },
             fir: Fir {
                 index: 3,
@@ -285,6 +289,7 @@ pub struct Compressor {
     pub ratio: u16,
     pub attack: u16,
     pub release: u16,
+    pub meter: u16,
 }
 
 /// A range of contiguous biquad filter addresses

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -538,6 +538,9 @@ impl<'a> Fir<'a> {
 
     /// Loads all coefficients into the filter, automatically setting the number of active taps
     pub async fn set_coefficients(&self, coefficients: &[f32]) -> Result<()> {
+        // The device will change the master mute status while loading the filter
+        let master_status = self.dsp.get_master_status().await?;
+
         // Set the number of active coefficients
         self.dsp
             .roundtrip(Commands::Write {
@@ -576,6 +579,9 @@ impl<'a> Fir<'a> {
 
         // Send load end
         self.dsp.roundtrip(Commands::FirLoadEnd).await?.into_ack()?;
+
+        // Set the master mute status back
+        self.dsp.set_master_mute(master_status.mute).await?;
 
         Ok(())
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -456,7 +456,7 @@ impl<'a> Compressor<'a> {
 
         self.dsp
             .roundtrip(Commands::Write {
-                addr: self.spec.threshold,
+                addr: self.spec.bypass,
                 value: Value::Int(value),
             })
             .await?
@@ -501,6 +501,19 @@ impl<'a> Compressor<'a> {
             })
             .await?
             .into_ack()
+    }
+
+    pub async fn get_level(&self) -> Result<f32> {
+        let view = self
+            .dsp
+            .roundtrip(Commands::ReadFloats {
+                addr: self.spec.meter,
+                len: 1,
+            })
+            .await?
+            .into_float_view()?;
+
+        Ok(view.get(self.spec.meter))
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -560,7 +560,7 @@ impl<'a> Fir<'a> {
             .into_fir_size()?;
 
         if coefficients.len() > max_coeff as usize {
-            return Err(MiniDSPError::TooManyCoefficients)
+            return Err(MiniDSPError::TooManyCoefficients);
         }
 
         // Load coefficients by chunk of 14 floats

--- a/src/server.rs
+++ b/src/server.rs
@@ -61,7 +61,7 @@ async fn forward(handle: Arc<dyn Transport>, mut tcp: TcpStream) -> Result<()> {
                 }
                 handle.send(tcp_recv_buf)
                     .await
-                    .map_err(|_| anyhow!("send error"))?;
+                    .map_err(|e| anyhow!("send error: {:?}", e))?;
             },
         }
     }

--- a/src/server.rs
+++ b/src/server.rs
@@ -20,10 +20,7 @@ async fn forward(handle: Arc<dyn Transport>, mut tcp: TcpStream) -> Result<()> {
     let decoder = {
         use termcolor::{ColorChoice, StandardStream};
         let writer = StandardStream::stderr(ColorChoice::Auto);
-        Arc::new(Mutex::new(Decoder {
-            w: Box::new(writer),
-            quiet: true,
-        }))
+        Arc::new(Mutex::new(Decoder::new(Box::new(writer), true)))
     };
 
     let mut recorder = match std::env::var("MINIDSP_LOG") {

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -32,6 +32,9 @@ pub enum MiniDSPError {
     #[error("This source was not recognized. Supported types are: 'toslink', 'usb', 'analog'")]
     InvalidSource,
 
+    #[error("There are too many coeffiients in this filter")]
+    TooManyCoefficients,
+
     #[error("Parse error")]
     ParseError(#[from] commands::ParseError),
 

--- a/src/utils/decoder.rs
+++ b/src/utils/decoder.rs
@@ -8,15 +8,32 @@ use std::fmt;
 use bytes::Bytes;
 use termcolor::{Color, ColorSpec, WriteColor};
 
+use crate::commands::{Commands, Responses};
+use crate::config::Setting;
 use crate::{commands, packet};
+use bimap::BiMap;
+use lazy_static::lazy_static;
+use strong_xml::XmlRead;
+
+lazy_static! {
+    static ref DEFAULT_CONFIG: Setting =
+        Setting::from_str(include_str!("../test_fixtures/config1/config.xml")).unwrap();
+    static ref NAME_MAP: BiMap<String, usize> = DEFAULT_CONFIG.name_map();
+}
 
 /// Main decoder
 pub struct Decoder {
-    pub quiet: bool,
-    pub w: Box<dyn WriteColor + Send + Sync>,
+    quiet: bool,
+    w: Box<dyn WriteColor + Send + Sync>,
 }
 
 impl Decoder {
+    pub fn new(w: Box<dyn WriteColor + Send + Sync>, quiet: bool) -> Self {
+        // Load name map from the default config
+
+        Decoder { quiet, w }
+    }
+
     /// Feed a sent frame
     pub fn feed_sent(&mut self, frame: &Bytes) {
         if let Ok(frame) = packet::unframe(frame.clone()) {
@@ -70,19 +87,21 @@ impl Decoder {
         Ok(())
     }
 
-    fn print_command<T: fmt::Debug>(&mut self, cmd: T) -> std::io::Result<()> {
+    fn print_command(&mut self, cmd: Commands) -> std::io::Result<()> {
         let _ = self.print_direction(true);
         let _ = self.w.set_color(ColorSpec::new().set_fg(Some(Color::Cyan)));
-        writeln!(self.w, "{:02x?}", cmd)?;
+        write!(self.w, "{:02x?} ", cmd)?;
+        let _ = self.maybe_print_addr(&ParsedMessage::Request(cmd.clone()));
         Ok(())
     }
 
-    fn print_response<T: fmt::Debug>(&mut self, cmd: T) -> std::io::Result<()> {
+    fn print_response(&mut self, cmd: Responses) -> std::io::Result<()> {
         let _ = self.print_direction(false);
         let _ = self
             .w
             .set_color(ColorSpec::new().set_fg(Some(Color::Green)));
-        writeln!(self.w, "{:02x?}", cmd)?;
+        write!(self.w, "{:02x?}", cmd)?;
+        let _ = self.maybe_print_addr(&ParsedMessage::Response(cmd.clone()));
         Ok(())
     }
 
@@ -104,6 +123,38 @@ impl Decoder {
         writeln!(self.w, "{:?}", err)?;
         Ok(())
     }
+
+    fn maybe_print_addr(&mut self, cmd: &ParsedMessage) -> std::io::Result<()> {
+        let addr = match cmd {
+            ParsedMessage::Request(Commands::ReadFloats { addr, .. }) => addr,
+            ParsedMessage::Request(Commands::Write { addr, .. }) => addr,
+            ParsedMessage::Request(Commands::WriteBiquad { addr, .. }) => addr,
+            ParsedMessage::Request(Commands::WriteBiquadBypass { addr, .. }) => addr,
+            _ => {
+                return writeln!(self.w);
+            }
+        };
+
+        let _ = self
+            .w
+            .set_color(ColorSpec::new().set_fg(Some(Color::Magenta)));
+
+        writeln!(
+            self.w,
+            "(0x{:02x?} | {:?}) <> {}",
+            addr,
+            addr,
+            NAME_MAP
+                .get_by_right(&(*addr as usize))
+                .unwrap_or(&"<unknown>".to_string())
+        )?;
+        Ok(())
+    }
+}
+
+pub enum ParsedMessage {
+    Request(Commands),
+    Response(Responses),
 }
 
 #[cfg(test)]

--- a/src/utils/decoder.rs
+++ b/src/utils/decoder.rs
@@ -91,7 +91,7 @@ impl Decoder {
         let _ = self.print_direction(true);
         let _ = self.w.set_color(ColorSpec::new().set_fg(Some(Color::Cyan)));
         write!(self.w, "{:02x?} ", cmd)?;
-        let _ = self.maybe_print_addr(&ParsedMessage::Request(cmd.clone()));
+        let _ = self.maybe_print_addr(&ParsedMessage::Request(cmd));
         Ok(())
     }
 
@@ -101,7 +101,7 @@ impl Decoder {
             .w
             .set_color(ColorSpec::new().set_fg(Some(Color::Green)));
         write!(self.w, "{:02x?}", cmd)?;
-        let _ = self.maybe_print_addr(&ParsedMessage::Response(cmd.clone()));
+        let _ = self.maybe_print_addr(&ParsedMessage::Response(cmd));
         Ok(())
     }
 

--- a/src/utils/decoder.rs
+++ b/src/utils/decoder.rs
@@ -16,9 +16,9 @@ use lazy_static::lazy_static;
 use strong_xml::XmlRead;
 
 lazy_static! {
-    static ref DEFAULT_CONFIG: Setting =
+    pub static ref DEFAULT_CONFIG: Setting =
         Setting::from_str(include_str!("../test_fixtures/config1/config.xml")).unwrap();
-    static ref NAME_MAP: BiMap<String, usize> = DEFAULT_CONFIG.name_map();
+    pub static ref NAME_MAP: BiMap<String, usize> = DEFAULT_CONFIG.name_map();
 }
 
 /// Main decoder

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,3 +1,4 @@
 pub mod decoder;
 pub mod lease;
 pub mod recorder;
+pub mod wav;

--- a/src/utils/wav.rs
+++ b/src/utils/wav.rs
@@ -1,0 +1,92 @@
+use std::path::Path;
+use thiserror::Error;
+#[derive(Error, Debug)]
+pub enum WavReadError {
+    #[error("IO Error")]
+    IOError(#[from] std::io::Error),
+    #[error("The file didn't match the device's internal sampling rate")]
+    InvalidSampleRate,
+    #[error("The file didn't contain any samples")]
+    NoData,
+}
+
+pub fn read_wav_filter<T: AsRef<Path>>(
+    filename: T,
+    sample_rate: u32,
+) -> Result<Vec<f32>, WavReadError> {
+    let mut inp_file = std::fs::File::open(filename)?;
+    let (header, data) = ::wav::read(&mut inp_file)?;
+
+    if header.sampling_rate != sample_rate {
+        return Err(WavReadError::InvalidSampleRate);
+    }
+
+    convert_data(data)
+}
+
+fn convert_data(data: wav::BitDepth) -> Result<Vec<f32>, WavReadError> {
+    let samples: Vec<f32>;
+
+    match data {
+        wav::BitDepth::Eight(data) => {
+            samples = data.iter().map(|x| (*x as f32 - 128.) / 128f32).collect();
+        }
+        wav::BitDepth::Sixteen(data) => {
+            samples = data.iter().map(|x| *x as f32 / (i16::MAX as f32)).collect();
+        }
+        wav::BitDepth::TwentyFour(data) => {
+            samples = data
+                .iter()
+                .map(|x| *x as f32 / ((1 << 23) as f32))
+                .collect();
+        }
+        wav::BitDepth::Empty => {
+            return Err(WavReadError::NoData);
+        }
+    }
+
+    Ok(samples)
+}
+
+#[cfg(test)]
+mod test {
+    use std::vec;
+
+    use wav::BitDepth;
+
+    use super::convert_data;
+    use assert_approx_eq::assert_approx_eq;
+
+    #[test]
+    fn test_u8() {
+        let data = BitDepth::Eight(vec![0, 255, 128]);
+        let expected: Vec<f32> = vec![-1.0, 1.0, 0.0];
+        let samples = convert_data(data).unwrap();
+
+        for (sample, expected) in samples.iter().zip(expected.iter()) {
+            assert_approx_eq!(*sample, *expected, 1e-2);
+        }
+    }
+
+    #[test]
+    fn test_i16() {
+        let data = BitDepth::Sixteen(vec![i16::MIN, 0, i16::MAX]);
+        let expected: Vec<f32> = vec![-1.0, 0.0, 1.0];
+        let samples = convert_data(data).unwrap();
+
+        for (sample, expected) in samples.iter().zip(expected.iter()) {
+            assert_approx_eq!(*sample, *expected, 1e-2);
+        }
+    }
+
+    #[test]
+    fn test_i24() {
+        let data = BitDepth::TwentyFour(vec![-1 << 23, 0, 1 << 23]);
+        let expected: Vec<f32> = vec![-1.0, 0.0, 1.0];
+        let samples = convert_data(data).unwrap();
+
+        for (sample, expected) in samples.iter().zip(expected.iter()) {
+            assert_approx_eq!(*sample, *expected, 1e-2);
+        }
+    }
+}

--- a/utils/firgen.py
+++ b/utils/firgen.py
@@ -1,14 +1,11 @@
 #!/usr/bin/env python3
-
-# import wave
-# with wave.open("filter.wav", mode='wb') as w:
-fs = 96000
+# Generates a low-pass filter at 200hz with a 500hz transition period for smoke-test testing of FIR import
 from scipy.signal import firwin
 import numpy as np
+from scipy.io import wavfile
+
+fs = 96000
 filter = firwin(512, 200, 500, fs=fs)
 filter = filter * (1<<15)
 filter = filter.astype(np.int16)
-
-from scipy.io import wavfile
-
 wavfile.write("filter.wav", fs, filter)

--- a/utils/firgen.py
+++ b/utils/firgen.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python3
+
+# import wave
+# with wave.open("filter.wav", mode='wb') as w:
+fs = 96000
+from scipy.signal import firwin
+import numpy as np
+filter = firwin(512, 200, 500, fs=fs)
+filter = filter * (1<<15)
+filter = filter.astype(np.int16)
+
+from scipy.io import wavfile
+
+wavfile.write("filter.wav", fs, filter)


### PR DESCRIPTION
`output n crossover <group> all import <filename>`
`output n crossover <group> all bypass on`
`output n crossover <group> all bypass on`

`output n fir import file.wav`
`output n fir bypass on`
`output n fir clear`

```
    minidsp output <output-index> compressor [OPTIONS]

OPTIONS:
    -a, --attack <attack>          Sets the attack time in ms
    -b, --bypass <bypass>          Bypass the compressor
    -k, --ratio <ratio>            Sets the ratio
    -r, --release <release>        Sets the release time in ms
    -t, --threshold <threshold>    Sets the threshold in dBFS
```



Closes #15 