### PR TITLE
Improve error handling and resiliance against malformed packets

### DIFF
--- a/debian/minidsp.service
+++ b/debian/minidsp.service
@@ -3,7 +3,7 @@ Description=MiniDSP Server
 After=network.target
 
 [Service]
-ExecStart=/usr/local/bin/minidsp server
+ExecStart=/usr/bin/minidsp server
 KillMode=process
 Restart=always
 

--- a/src/bin/minidsp/debug.rs
+++ b/src/bin/minidsp/debug.rs
@@ -23,7 +23,7 @@ pub(crate) async fn run_debug(device: &MiniDSP<'_>, debug: DebugCommands) -> Res
                     cmd_id: value[0],
                     payload: BytesWrap(value.slice(1..)),
                 },
-                None,
+                |_| true,
             )
             .await?;
 

--- a/src/bin/minidsp/main.rs
+++ b/src/bin/minidsp/main.rs
@@ -56,9 +56,7 @@ enum SubCommand {
     Probe,
 
     /// Set the master output gain [-127, 0]
-    Gain {
-        value: Gain,
-    },
+    Gain { value: Gain },
 
     /// Set the master mute status
     Mute {

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -488,35 +488,50 @@ impl Responses {
     pub fn into_memory_view(self) -> Result<MemoryView, MiniDSPError> {
         match self {
             Responses::MemoryData(m) => Ok(m),
-            _ => Err(MiniDSPError::MalformedResponse),
+            _ => Err(MiniDSPError::MalformedResponse(format!(
+                "Expected a MemoryView, but got a {:?}",
+                self
+            ))),
         }
     }
 
     pub fn into_float_view(self) -> Result<FloatView, MiniDSPError> {
         match self {
             Responses::FloatData(m) => Ok(m),
-            _ => Err(MiniDSPError::MalformedResponse),
+            _ => Err(MiniDSPError::MalformedResponse(format!(
+                "Expected a FloatView, but got a {:?}",
+                self
+            ))),
         }
     }
 
     pub fn into_hardware_id(self) -> Result<u8, MiniDSPError> {
         match self {
             Responses::HardwareId { payload } => Ok(payload[2]),
-            _ => Err(MiniDSPError::MalformedResponse),
+            _ => Err(MiniDSPError::MalformedResponse(format!(
+                "Expected a HardwareId, but got a {:?}",
+                self
+            ))),
         }
     }
 
     pub fn into_ack(self) -> Result<(), MiniDSPError> {
         match self {
             Responses::Ack => Ok(()),
-            _ => Err(MiniDSPError::MalformedResponse),
+            _ => Err(MiniDSPError::MalformedResponse(format!(
+                "Expected an Ack, but got a {:?}",
+                self
+            ))),
         }
     }
 
     pub fn into_fir_size(self) -> Result<u16, MiniDSPError> {
         match self {
             Responses::FirLoadSize { size } => Ok(size),
-            _ => Err(MiniDSPError::MalformedResponse),
+            _ => Err(MiniDSPError::MalformedResponse(format!(
+                "Expected an FirSize, but got a {:?}",
+                self
+            ))),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -116,8 +116,11 @@ impl MiniDSP<'_> {
     pub async fn get_master_status(&self) -> Result<MasterStatus> {
         let device_info = self.get_device_info().await?;
         let memory = read_memory(self.transport.as_ref(), 0xffd8, 8).await?;
-        Ok(MasterStatus::from_memory(&device_info, &memory)
-            .map_err(|_| MiniDSPError::MalformedResponse)?)
+        Ok(
+            MasterStatus::from_memory(&device_info, &memory).map_err(|e| {
+                MiniDSPError::MalformedResponse(format!("Couldn't convert to MemoryView: {:?}", e))
+            })?,
+        )
     }
 
     /// Gets the current input levels

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -26,11 +26,16 @@ pub fn checksum<T: AsRef<[u8]>>(data: T) -> u8 {
 /// Extracts the packet's data by looking at its first byte for its length
 pub fn unframe(response: Bytes) -> Result<Bytes, MiniDSPError> {
     if response.is_empty() {
-        return Err(MalformedResponse);
+        return Err(MalformedResponse("Packet was empty".to_string()));
     }
     let len = response[0] as usize;
     if response.len() < len {
-        Err(MalformedResponse)
+        Err(MalformedResponse(format!(
+            "Expected a packet of length {}, but got {} instead. (Data={})",
+            len,
+            response.len(),
+            hex::encode(response)
+        )))
     } else {
         Ok(response.slice(1..len))
     }

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -26,8 +26,8 @@ pub enum MiniDSPError {
     #[error("IO error: {0}")]
     IOError(#[from] std::io::Error),
 
-    #[error("A malformed packet was received")]
-    MalformedResponse,
+    #[error("A malformed packet was received: {0}")]
+    MalformedResponse(String),
 
     #[error("This source was not recognized. Supported types are: 'toslink', 'usb', 'analog'")]
     InvalidSource,


### PR DESCRIPTION
- Adds explicit error messages detailing why the response was malformed
- Calls wait for an `Ack` response packet by default
- There might be some cases left where packets get fragmented - the upcoming transport refactor should solve those
refs #21 