### PR TITLE
feat(api): allow streaming input/output meter levels

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -732,6 +732,7 @@ dependencies = [
  "okapi",
  "once_cell",
  "routerify",
+ "routerify-query",
  "routerify-unixsocket",
  "schemars",
  "serde",
@@ -740,6 +741,7 @@ dependencies = [
  "termcolor 1.1.2",
  "thiserror",
  "tokio",
+ "tokio-stream",
  "tokio-util",
  "tungstenite",
  "url2",
@@ -1112,6 +1114,16 @@ dependencies = [
  "lazy_static",
  "percent-encoding",
  "regex",
+]
+
+[[package]]
+name = "routerify-query"
+version = "2.0.0"
+source = "git+https://github.com/routerify/routerify-query?branch=master#e1057f5dc3def1c0eba46f9a4b70607b252124c1"
+dependencies = [
+ "hyper",
+ "routerify",
+ "url",
 ]
 
 [[package]]

--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -28,12 +28,14 @@ minidsp = {path = "../minidsp"}
 okapi = "0.5.0-alpha-1"
 once_cell = "1.7.2"
 routerify = "2.0.2"
+routerify-query = { git="https://github.com/routerify/routerify-query", branch="master" }
 schemars = {version = "0.8.3", optional = true}
 serde = {version = "1.0.126", features = ["derive"], optional = true}
 serde_json = "1.0.64"
 strum = {version = "0.20.0", features = ["derive"], optional = true}
 termcolor = "1.1.2"
 thiserror = "1.0.24"
+tokio-stream = {version = "0.1.5", features = ["sync"]}
 tungstenite = "0.13.0"
 url2 = "0.0.6"
 

--- a/daemon/src/http/mod.rs
+++ b/daemon/src/http/mod.rs
@@ -1,4 +1,4 @@
-use std::{fmt::Debug, net::SocketAddr, str::FromStr, sync::Arc};
+use std::{fmt::Debug, net::SocketAddr, str::FromStr, sync::Arc, time::Duration};
 
 use anyhow::Context;
 use futures::{future::join_all, SinkExt, StreamExt};
@@ -6,11 +6,13 @@ use hyper::{Body, Request, Response, Server, StatusCode};
 use minidsp::{
     model::{Config, MasterStatus, StatusSummary},
     utils::{ErrInto, OwnedJoinHandle},
-    MiniDSP,
+    MiniDSP, MiniDSPError,
 };
 use routerify::{Router, RouterService};
+use routerify_query::{query_parser, RequestQueryExt};
 use schemars::JsonSchema;
 use serde::Serialize;
+use tokio_stream::wrappers::IntervalStream;
 use tungstenite::Message;
 use websocket::websocket_transport_bridge;
 
@@ -126,6 +128,7 @@ async fn get_master_status(req: Request<Body>) -> Result<Response<Body>, Error> 
     let app = app.read().await;
     let device = get_device_instance(&app, device_index)?;
     let status = StatusSummary::fetch(&device).await?;
+    let query_levels = req.query("levels").map(Clone::clone);
 
     if hyper_tungstenite::is_upgrade_request(&req) {
         let (response, websocket) =
@@ -139,22 +142,49 @@ async fn get_master_status(req: Request<Body>) -> Result<Response<Body>, Error> 
                 .send(Message::Text(serde_json::to_string(&status).unwrap()))
                 .await?;
 
-            device
+            let status_stream = device
                 .subscribe_master_status()
                 .await?
                 .filter_map(|master| async move {
-                    if master.eq(&minidsp::MasterStatus::default()) {
-                        None
-                    } else {
-                        let summary = StatusSummary {
-                            master: minidsp::model::MasterStatus::from(master),
-                            ..Default::default()
-                        };
+                    let summary = StatusSummary {
+                        master: minidsp::model::MasterStatus::from(master),
+                        ..Default::default()
+                    };
 
-                        let s = serde_json::to_string(&summary).unwrap();
-                        Some(Ok(Message::Text(s)))
-                    }
+                    let s = serde_json::to_string(&summary).unwrap();
+                    Some(Ok(Message::Text(s)))
                 })
+                .boxed();
+
+            let levels = {
+                if query_levels.is_some() {
+                    // Use a single shared device instance in order to avoid multiple level queries from being done simultaneously
+                    let levels_device = Arc::new(tokio::sync::Mutex::new(device));
+                    IntervalStream::new(tokio::time::interval(Duration::from_millis(250)))
+                        .filter_map(move |_| {
+                            let device = levels_device.clone();
+                            async move {
+                                // If we are already querying for levels, skip this interval.
+                                let device = device.try_lock().ok()?;
+
+                                let (input_levels, output_levels) =
+                                    device.get_input_output_levels().await.ok()?;
+                                let summary = StatusSummary {
+                                    input_levels,
+                                    output_levels,
+                                    ..Default::default()
+                                };
+                                let s = serde_json::to_string(&summary).unwrap();
+                                Some(Ok::<_, tungstenite::Error>(Message::Text(s)))
+                            }
+                        })
+                        .boxed()
+                } else {
+                    futures::stream::empty().boxed()
+                }
+            };
+
+            futures::stream::select_all(std::array::IntoIter::new([status_stream, levels]))
                 .forward(websocket)
                 .await?;
 
@@ -187,8 +217,6 @@ async fn post_master_status(mut req: Request<Body>) -> Result<Response<Body>, Er
 /// Updates the device's configuration based on the defined elements. Anything set will be changed and anything else will be ignored.
 /// If a `master_status` object is passed, and the active configuration is changed, it will be applied before anything else. it is therefore
 /// safe to change config and apply other changes to the target config using a single call.
-// #[post("/<index>/config", data = "<data>")]
-// async fn post_config(index: usize, data: Json<Config>) -> Result<(), Json<FormattedError>> {
 async fn post_config(mut req: Request<Body>) -> Result<Response<Body>, Error> {
     let device_index: usize = parse_param(&req, "deviceIndex")?;
     let app = super::APP.get().unwrap();
@@ -237,6 +265,7 @@ fn router() -> Router<Body, Error> {
     // Here, "Middleware::pre" means we're adding a pre middleware which will be executed
     // before any route handlers.
     Router::builder()
+        .middleware(query_parser())
         // .middleware(Middleware::pre(logger))
         .get("/openapi.json", |req| async move {
             Ok(serialize_response(&req, openapi::schema())?)

--- a/daemon/src/http/mod.rs
+++ b/daemon/src/http/mod.rs
@@ -6,7 +6,7 @@ use hyper::{Body, Request, Response, Server, StatusCode};
 use minidsp::{
     model::{Config, MasterStatus, StatusSummary},
     utils::{ErrInto, OwnedJoinHandle},
-    MiniDSP, MiniDSPError,
+    MiniDSP
 };
 use routerify::{Router, RouterService};
 use routerify_query::{query_parser, RequestQueryExt};

--- a/daemon/src/http/mod.rs
+++ b/daemon/src/http/mod.rs
@@ -6,7 +6,7 @@ use hyper::{Body, Request, Response, Server, StatusCode};
 use minidsp::{
     model::{Config, MasterStatus, StatusSummary},
     utils::{ErrInto, OwnedJoinHandle},
-    MiniDSP
+    MiniDSP,
 };
 use routerify::{Router, RouterService};
 use routerify_query::{query_parser, RequestQueryExt};

--- a/daemon/src/http/websocket.rs
+++ b/daemon/src/http/websocket.rs
@@ -1,6 +1,6 @@
 use anyhow::Context;
 use bytes::Bytes;
-use futures::StreamExt;
+use futures::{Sink, SinkExt, StreamExt};
 use hyper_tungstenite::HyperWebsocket;
 use minidsp::{transport::Hub, MiniDSPError};
 use tungstenite::Message;

--- a/daemon/src/http/websocket.rs
+++ b/daemon/src/http/websocket.rs
@@ -1,6 +1,6 @@
 use anyhow::Context;
 use bytes::Bytes;
-use futures::{Sink, SinkExt, StreamExt};
+use futures::StreamExt;
 use hyper_tungstenite::HyperWebsocket;
 use minidsp::{transport::Hub, MiniDSPError};
 use tungstenite::Message;

--- a/minidsp/src/client.rs
+++ b/minidsp/src/client.rs
@@ -11,6 +11,7 @@ use crate::{
     DeviceInfo,
 };
 
+#[derive(Clone)]
 pub struct Client {
     transport: SharedService,
 }

--- a/minidsp/src/lib.rs
+++ b/minidsp/src/lib.rs
@@ -131,7 +131,7 @@ impl MiniDSP<'_> {
                         return Some(status);
                     }
                 }
-                return None;
+                None
             });
         Ok(Box::pin(stream))
     }


### PR DESCRIPTION
If a query string param named `levels` is passed, the current meters will be polled at most every 250ms (the actual timing depends on how fast the device responds).

Example:
```
$ websocat "ws://127.0.0.1:5380/devices/0?levels=true" 
{"master":{"preset":0,"source":"Toslink","volume":-23.5,"mute":false},"input_levels":[-131.39247,-131.39247],"output_levels":[-155.63495,-155.38512,-120.0,-120.0]}
{"master":{},"input_levels":[-131.44687,-131.44687],"output_levels":[-155.71179,-155.45367,-120.0,-120.0]}
{"master":{},"input_levels":[-131.45757,-131.45757],"output_levels":[-155.7264,-155.46838,-120.0,-120.0]}
{"master":{},"input_levels":[-131.39085,-131.39085],"output_levels":[-155.65402,-155.39429,-120.0,-120.0]}
{"master":{},"input_levels":[-131.42593,-131.42593],"output_levels":[-155.71394,-155.44768,-120.0,-120.0]}
{"master":{},"input_levels":[-131.37611,-131.37611],"output_levels":[-155.61394,-155.3645,-120.0,-120.0]}
{"master":{},"input_levels":[-131.4686,-131.4686],"output_levels":[-155.73004,-155.47478,-120.0,-120.0]}
{"master":{},"input_levels":[-131.40887,-131.40887],"output_levels":[-155.69489,-155.42479,-120.0,-120.0]}
{"master":{},"input_levels":[-131.41469,-131.41469],"output_levels":[-155.66344,-155.4142,-120.0,-120.0]}
```

Refs #115 