### PR TITLE
Add --relative (-r) option to the gain command.

### DIFF
--- a/minidsp/src/bin/minidsp/debug.rs
+++ b/minidsp/src/bin/minidsp/debug.rs
@@ -90,10 +90,7 @@ pub(crate) async fn run_debug(device: &MiniDSP<'_>, debug: &DebugCommands) -> Re
                 return Err(anyhow::anyhow!("Serial must be between 900000 and 965535"));
             }
             let value: u16 = (value - 900000).try_into().unwrap();
-            device
-                .client
-                .write_u16(eeprom::SERIAL_SHORT, value)
-                .await?;
+            device.client.write_u16(eeprom::SERIAL_SHORT, value).await?;
         }
     }
 

--- a/minidsp/src/bin/minidsp/handlers.rs
+++ b/minidsp/src/bin/minidsp/handlers.rs
@@ -48,7 +48,16 @@ pub(crate) async fn run_command(
 ) -> Result<()> {
     match cmd {
         // Master
-        Some(&SubCommand::Gain { value }) => device.set_master_volume(value).await?,
+        Some(&SubCommand::Gain {
+            mut value,
+            relative,
+        }) => {
+            if relative {
+                let status = device.get_master_status().await?;
+                value.0 += status.volume.unwrap().0;
+            }
+            device.set_master_volume(value).await?
+        }
         Some(&SubCommand::Mute { value }) => device.set_master_mute(value).await?,
         Some(&SubCommand::Source { value }) => device.set_source(value).await?,
         Some(&SubCommand::Config { value }) => device.set_config(value).await?,

--- a/minidsp/src/bin/minidsp/main.rs
+++ b/minidsp/src/bin/minidsp/main.rs
@@ -147,6 +147,9 @@ enum SubCommand {
 
     /// Set the master output gain [-127, 0]
     Gain {
+        #[clap(long, short)]
+        relative: bool,
+
         /// Gain in decibels, between -127 and 0 inclusively
         value: Gain,
     },

--- a/minidsp/src/bin/minidsp/main.rs
+++ b/minidsp/src/bin/minidsp/main.rs
@@ -148,6 +148,7 @@ enum SubCommand {
     /// Set the master output gain [-127, 0]
     Gain {
         #[clap(long, short)]
+        /// Specify the value as a relative increment on top of the current gain.
         relative: bool,
 
         /// Gain in decibels, between -127 and 0 inclusively


### PR DESCRIPTION
Refs #230

The gain can be changed in relative increments, this increases or decreases by 5dB, respectively: `minidsp gain --relative 5` or `minidsp gain --relative -- -5`

```
$ minidsp gain --help

minidsp-gain
Set the master output gain [-127, 0]

USAGE:
    minidsp gain [OPTIONS] <VALUE>

ARGS:
    <VALUE>    Gain in decibels, between -127 and 0 inclusively

OPTIONS:
    -h, --help        Print help information
    -r, --relative    Specify the value as a relative increment on top of the current gain
```