### PR TITLE
Add aarch64 build to automated releases

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -56,6 +56,8 @@ jobs:
             bin: minidsp
             svc_bin: minidspd
             cross: true
+            cross_image: local/aarch64-unknown-linux-gnu-0.2.1
+            cross_dockerfile: Dockerfile.aarch64
             archive: tar.gz
           - target: x86_64-apple-darwin
             os: macOS-latest
@@ -84,8 +86,13 @@ jobs:
           override: true
 
       - name: Install native packages
-        if: runner.os == 'Linux'
+        if: runner.os == 'Linux' && matrix.pair.cross == false
         run: sudo apt-get install libusb-1.0-0 libusb-1.0-0-dev
+
+      - name: Build cross image
+        if: runner.os == 'Linux' && matrix.pair.cross == true
+        run: |
+          docker build -t ${{ matrix.pair.cross_image }} -f ${{ matrix.pair.cross_dockerfile }} scripts/
 
       # From https://github.com/NLnetLabs/krill/blob/master/.github/workflows/pkg.yml
       # Speed up cargo-deb installation by only re-downloading and re-building its

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -74,7 +74,7 @@ jobs:
 
     runs-on: ${{ matrix.pair.os }}
     env:
-      CARGO_DEB_VER: 1.28.2
+      CARGO_DEB_VER: 1.35.0
 
     steps:
       - uses: actions/checkout@v2.3.4

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -3,7 +3,7 @@ name: Release build
 on:
   push:
     branches:
-      - 'force-build'
+      - 'arm64'
     tags:
       - 'v0.*'
       - 'v1.*'
@@ -50,6 +50,12 @@ jobs:
             bin: minidsp
             svc_bin: minidspd
             cross: false
+            archive: tar.gz
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-latest
+            bin: minidsp
+            svc_bin: minidspd
+            cross: true
             archive: tar.gz
           - target: x86_64-apple-darwin
             os: macOS-latest

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -92,7 +92,7 @@ jobs:
       - name: Build cross image
         if: runner.os == 'Linux' && matrix.pair.cross == true
         run: |
-          docker build -t ${{ matrix.pair.cross_image }} -f ${{ matrix.pair.cross_dockerfile }} scripts/
+          docker build -t ${{ matrix.pair.cross_image }} -f scripts/${{ matrix.pair.cross_dockerfile }} scripts/
 
       # From https://github.com/NLnetLabs/krill/blob/master/.github/workflows/pkg.yml
       # Speed up cargo-deb installation by only re-downloading and re-building its

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -120,7 +120,7 @@ jobs:
       - name: Create debian package
         if: runner.os == 'Linux'
         run: |
-          cargo deb --target ${{ matrix.pair.target }} -p minidsp
+          cargo deb --target ${{ matrix.pair.target }} -p minidsp --no-build --no-strip
           cp -v target/${{ matrix.pair.target }}/debian/${{ matrix.pair.bin }}* .
 
       - name: Upload debian package

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,3 +5,4 @@ members = ["minidsp", "protocol", "daemon", "devtools"]
 codegen-units = 1
 lto = true
 opt-level = 3
+strip = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,4 +5,3 @@ members = ["minidsp", "protocol", "daemon", "devtools"]
 codegen-units = 1
 lto = true
 opt-level = 3
-strip = true

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,0 +1,3 @@
+[target.aarch64-unknown-linux-gnu]
+image = "local/aarch64-unknown-linux-gnu-0.2.1"
+

--- a/scripts/Dockerfile.aarch64
+++ b/scripts/Dockerfile.aarch64
@@ -1,0 +1,2 @@
+FROM rustembedded/cross:aarch64-unknown-linux-gnu-0.2.1
+RUN dpkg --add-architecture arm64 && apt-get update && apt-get install -y libusb-1.0-0-dev:arm64 pkg-config

--- a/scripts/Dockerfile.aarch64
+++ b/scripts/Dockerfile.aarch64
@@ -1,2 +1,3 @@
 FROM rustembedded/cross:aarch64-unknown-linux-gnu-0.2.1
 RUN dpkg --add-architecture arm64 && apt-get update && apt-get install -y libusb-1.0-0-dev:arm64 pkg-config
+ENV PKG_CONFIG_LIBDIR=/usr/lib/aarch64-linux-gnu/pkgconfig


### PR DESCRIPTION
- feat(build): add arm64 tenatative cross build
- feat(build): build local docker container with libusb before cross build
- feat(build): build local docker container with libusb before cross build
- fix(build): set aarch64 pkg config path
- fix(build): bump cargo deb version
- fix(build): strip within cargo build, so cargo-deb can run on the host without the target being present
- fix(build): don't add strip = true until rust 1.60

closes #198 