### PR TITLE
Fill in device information in advertisement packets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -563,7 +563,7 @@ checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
 
 [[package]]
 name = "minidsp"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "anyhow",
  "assert_approx_eq",
@@ -606,7 +606,7 @@ dependencies = [
 
 [[package]]
 name = "minidsp-daemon"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "anyhow",
  "bytes",
@@ -641,7 +641,7 @@ dependencies = [
 
 [[package]]
 name = "minidsp-devtools"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "Inflector",
  "anyhow",
@@ -662,7 +662,7 @@ dependencies = [
 
 [[package]]
 name = "minidsp-protocol"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,9 +23,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.65"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98161a4e3e2184da77bb14f02184cdd111e83bbbcc9979dfee3c44b9a85f5602"
+checksum = "216261ddc8289130e551ddcd5ce8a064710c0d064a4d2895c67151c92b5443f6"
 
 [[package]]
 name = "assert_approx_eq"
@@ -35,9 +35,9 @@ checksum = "3c07dab4369547dbe5114677b33fbbf724971019f3818172d59a97a61c774ffd"
 
 [[package]]
 name = "async-trait"
-version = "0.1.57"
+version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76464446b8bc32758d7e88ee1a804d9914cd9b1cb264c029899680b0be29826f"
+checksum = "1e805d94e6b5001b651426cf4cd446b1ab5f319d27bab5c644f61de0a804360c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -126,9 +126,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "4.0.11"
+version = "4.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ed45cc2c62a3eff523e718d8576ba762c83a3146151093283ac62ae11933a73"
+checksum = "335867764ed2de42325fafe6d18b8af74ba97ee0c590fa016f157535b42ab04b"
 dependencies = [
  "atty",
  "bitflags",
@@ -141,9 +141,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.0.10"
+version = "4.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db342ce9fda24fb191e2ed4e102055a4d381c1086a06630174cd8da8d5d917ce"
+checksum = "16a1b0f6422af32d5da0c58e2703320f379216ee70198241c84173a8c5ac28f3"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -260,9 +260,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f21eda599937fba36daeb58a22e8f5cee2d14c4a17b5b7739c7c8e5e3b8230c"
+checksum = "38390104763dc37a5145a53c29c63c1290b5d316d6086ec32c293f6736051bb0"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -275,9 +275,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30bdd20c28fadd505d0fd6712cdfcb0d4b5648baf45faef7f852afb2399bb050"
+checksum = "52ba265a92256105f45b719605a571ffe2d1f0fea3807304b522c1d778f79eed"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -285,15 +285,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e5aa3de05362c3fb88de6531e6296e85cde7739cccad4b9dfeeb7f6ebce56bf"
+checksum = "04909a7a7e4633ae6c4a9ab280aeb86da1236243a77b694a49eacd659a4bd3ac"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ff63c23854bee61b6e9cd331d523909f238fc7636290b96826e9cfa5faa00ab"
+checksum = "7acc85df6714c176ab5edf386123fafe217be88c0840ec11f199441134a074e2"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -302,15 +302,15 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbf4d2a7a308fd4578637c0b17c7e1c7ba127b8f6ba00b29f717e9655d85eb68"
+checksum = "00f5fb52a06bdcadeb54e8d3671f8888a39697dcb0b81b23b55174030427f4eb"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42cd15d1c7456c04dbdf7e88bcd69760d74f3a798d6444e16974b505b0e62f17"
+checksum = "bdfb8ce053d86b91919aad980c220b1fb8401a9394410e1c289ed7e66b61835d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -319,21 +319,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b20ba5a92e727ba30e72834706623d94ac93a725410b6a6b6fbc1b07f7ba56"
+checksum = "39c15cf1a4aa79df40f1bb462fb39676d0ad9e366c2a33b590d7c66f4f81fcf9"
 
 [[package]]
 name = "futures-task"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6508c467c73851293f390476d4491cf4d227dbabcd4170f3bb6044959b294f1"
+checksum = "2ffb393ac5d9a6eaa9d3fdf37ae2776656b706e200c8e16b1bdb227f5198e6ea"
 
 [[package]]
 name = "futures-util"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44fb6cb1be61cc1d2e43b262516aafcf63b241cffdb1d3fa115f91d9c7b09c90"
+checksum = "197676987abd2f9cadff84926f410af1c183608d36641465df73ae8211dc65d6"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -794,9 +794,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.46"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94e2ef8dbfc347b10c094890f778ee2e36ca9bb4262e86dc99cd217e35f3470b"
+checksum = "5ea3d908b0e36316caf9e9e2c4625cdde190a7e6f440d794667ed17a1855e725"
 dependencies = [
  "unicode-ident",
 ]
@@ -958,18 +958,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.145"
+version = "1.0.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "728eb6351430bccb993660dfffc5a72f91ccc1295abaa8ce19b27ebe4f75568b"
+checksum = "d193d69bae983fc11a79df82342761dfbf28a99fc8d203dca4c3c1b590948965"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.145"
+version = "1.0.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81fa1584d3d1bcacd84c277a0dfe21f5b0f6accf4a23d04d4c6d61f1af522b4c"
+checksum = "4f1d362ca8fc9c3e3a7484440752472d68a6caa98f1ab81d99b5dfe517cec852"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -989,9 +989,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.85"
+version = "1.0.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e55a28e3aaef9d5ce0506d0a14dbba8054ddc7e499ef522dd8b26859ec9d4a44"
+checksum = "6ce777b7b150d76b9cf60d28b55f5847135a003f7d7350c6be7a773508ce7d45"
 dependencies = [
  "itoa",
  "ryu",
@@ -1182,9 +1182,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6edf2d6bc038a43d31353570e27270603f4648d18f5ed10c0e179abe43255af"
+checksum = "d660770404473ccd7bc9f8b28494a811bc18542b915c0855c51e8f419d5223ce"
 dependencies = [
  "futures-core",
  "pin-project-lite",

--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["Mathieu Rene <mathieu.rene@gmail.com>"]
 edition = "2021"
 name = "minidsp-daemon"
-version = "0.1.7"
+version = "0.1.8"
 license = "Apache-2.0"
 description = "A control interface for some MiniDSP products"
 repository = "https://github.com/mrene/minidsp-rs"

--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -15,14 +15,14 @@ path = "src/main.rs"
 default = ["serde", "strum", "schemars"]
 
 [dependencies]
-anyhow = "1.0.65"
+anyhow = "1.0.66"
 bytes = "1.2.1"
-clap = "4.0.11"
+clap = "4.0.18"
 confy = "0.5.0"
 env_logger = "0.9.1"
-futures = "0.3.24"
-futures-sink = "0.3.24"
-futures-util = "0.3.24"
+futures = "0.3.25"
+futures-sink = "0.3.25"
+futures-util = "0.3.25"
 hyper = "0.14.20"
 hyper-tungstenite = "0.8.1"
 lazy_static = "1.4.0"
@@ -33,12 +33,12 @@ once_cell = "1.15.0"
 routerify = "3.0.0"
 routerify-query = "3.0.0"
 schemars = { version = "0.8.11", optional = true }
-serde = { version = "1.0.145", features = ["derive"], optional = true }
-serde_json = "1.0.85"
+serde = { version = "1.0.147", features = ["derive"], optional = true }
+serde_json = "1.0.87"
 strum = { version = "0.24.1", features = ["derive"], optional = true }
 termcolor = "1.1.3"
 thiserror = "1.0.37"
-tokio-stream = { version = "0.1.10", features = ["sync"] }
+tokio-stream = { version = "0.1.11", features = ["sync"] }
 url2 = "0.0.6"
 
 [dependencies.tokio]

--- a/daemon/src/config.rs
+++ b/daemon/src/config.rs
@@ -70,4 +70,7 @@ pub struct Advertise {
 
     /// Defines the name used in the advertisement packets
     pub name: String,
+
+    /// Bind address to use when sending broadcast packets
+    pub bind: String,
 }

--- a/daemon/src/config.rs
+++ b/daemon/src/config.rs
@@ -16,6 +16,10 @@ pub struct Config {
     /// If a remote device is not being discovered, it can be added to this list.
     #[serde(rename = "static_device")]
     pub static_devices: Vec<StaticDevice>,
+
+    /// Set to ignore network devices that broadcast advertisement packets (such as the WI-DG).
+    /// It's still possible to add them using `[[static_device]]`
+    pub ignore_advertisements: bool,
 }
 
 impl Default for Config {
@@ -26,6 +30,7 @@ impl Default for Config {
             }),
             tcp_servers: Vec::new(),
             static_devices: Vec::new(),
+            ignore_advertisements: false,
         }
     }
 }
@@ -72,5 +77,5 @@ pub struct Advertise {
     pub name: String,
 
     /// Bind address to use when sending broadcast packets
-    pub bind: String,
+    pub bind_address: Option<String>,
 }

--- a/daemon/src/http/openapi/mod.rs
+++ b/daemon/src/http/openapi/mod.rs
@@ -196,6 +196,8 @@ pub fn schema() -> OpenApi {
                 hw_id: 10,
                 dsp_version: 100,
                 serial: 91234,
+                fw_major: 1,
+                fw_minor: 53,
             }),
             product_name: Some("2x4 HD".into()),
         };

--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -86,7 +86,7 @@ impl App {
             })
             .collect();
 
-        let device_mgr = DeviceManager::new(registry, our_ips);
+        let device_mgr = DeviceManager::new(registry, our_ips, self.config.ignore_advertisements);
 
         let http_server = self.config.http_server.clone();
         self.handles.push(

--- a/daemon/src/tcp/mod.rs
+++ b/daemon/src/tcp/mod.rs
@@ -82,10 +82,10 @@ pub fn start_advertise(
                 mac_address: [10, 20, 30, 40, 50, 60],
                 ip_address: Ipv4Addr::from_str(&advertise.ip)?,
                 hwid: 27,
+                dsp_id: 100,
                 fw_major: 1,
                 fw_minor: 53,
-                dsp_id: 0,
-                sn: 65535,
+                sn: 1234,
                 hostname: advertise.name.to_string(),
             };
             let interval = Duration::from_secs(1);

--- a/daemon/src/tcp/mod.rs
+++ b/daemon/src/tcp/mod.rs
@@ -1,7 +1,9 @@
 //! TCP server compatible with the official mobile and desktop application
+use core::panic;
 use std::{
-    net::{Ipv4Addr, SocketAddr, ToSocketAddrs},
+    net::{Ipv4Addr, ToSocketAddrs},
     str::FromStr,
+    sync::Arc,
     time::Duration,
 };
 
@@ -20,6 +22,8 @@ use tokio::{
     select,
 };
 use tokio_util::codec::Framed;
+
+use crate::{device_manager::Device, App};
 
 use super::config;
 
@@ -72,25 +76,45 @@ where
     }
 }
 
-pub fn start_advertise(
-    bind_addr: SocketAddr,
-    config: &config::Config,
-) -> Result<(), anyhow::Error> {
-    for srv in &config.tcp_servers {
+pub fn start_advertise(app: &App, cfg: Arc<config::TcpServer>) -> Result<(), anyhow::Error> {
+    for srv in &app.config.tcp_servers {
         if let Some(ref advertise) = srv.advertise {
-            let packet = discovery::DiscoveryPacket {
-                mac_address: [10, 20, 30, 40, 50, 60],
-                ip_address: Ipv4Addr::from_str(&advertise.ip)?,
-                hwid: 27,
-                dsp_id: 100,
-                fw_major: 1,
-                fw_minor: 53,
-                sn: 1234,
-                hostname: advertise.name.to_string(),
+            let ip_address = Ipv4Addr::from_str(&advertise.ip)?;
+            let hostname: Arc<str> = Arc::from(advertise.name.clone());
+            let cfg = cfg.clone();
+            let packet_fn = move || -> Option<discovery::DiscoveryPacket> {
+                // Find a suitable device to forward this client to
+                let device = device_matches(&cfg).ok()?;
+                let device_info = device.device_info()?;
+
+                let mut packet = discovery::DiscoveryPacket {
+                    // The mac address is used to distinguish between devices on the *device list* page in the MiniDSP Device Console app
+                    mac_address: [0xFF, 0xFF, 0x00, 0x00, 0x00, 0x00],
+                    ip_address,
+                    hwid: device_info.hw_id,
+                    dsp_id: device_info.dsp_version,
+                    fw_major: device_info.fw_major,
+                    fw_minor: device_info.fw_minor,
+                    sn: ((device_info.serial - 900000) & 0xFFFF) as u16,
+                    hostname: hostname.to_string(),
+                };
+
+                // Use a unique MAC by stitching the IP's bytes in the last 4 bytes
+                packet.mac_address[2..].copy_from_slice(&packet.ip_address.octets());
+
+                Some(packet)
             };
+
+            let bind_addr = match &advertise.bind_address {
+                None => None,
+                Some(addr) => Some(addr.to_socket_addrs()?.next().ok_or_else(|| {
+                    anyhow::anyhow!("bind adddress didn't resolve to a usable address")
+                })?),
+            };
+
             let interval = Duration::from_secs(1);
             tokio::spawn(discovery::server::advertise_packet(
-                bind_addr, packet, interval,
+                bind_addr, packet_fn, interval,
             ));
         }
     }
@@ -100,17 +124,11 @@ pub fn start_advertise(
 pub async fn main(cfg: config::TcpServer) -> Result<(), MiniDSPError> {
     let app = super::APP.get().unwrap();
     let app = app.read().await;
+    let cfg = Arc::new(cfg);
 
-    let bind_address = cfg
-        .bind_address
-        .unwrap_or_else(|| "0.0.0.0:5333".to_string());
+    let bind_address = cfg.bind_address.as_deref().unwrap_or("0.0.0.0:5333");
 
-    let bind_addr = bind_address
-        .to_socket_addrs()?
-        .next()
-        .ok_or_else(|| anyhow::anyhow!("bind adddress didn't resolve to a usable address"))?;
-
-    if let Err(adv_err) = start_advertise(bind_addr, &app.config) {
+    if let Err(adv_err) = start_advertise(&app, cfg.clone()) {
         log::error!("error launching advertisement task: {:?}", adv_err);
     }
 
@@ -122,23 +140,10 @@ pub async fn main(cfg: config::TcpServer) -> Result<(), MiniDSPError> {
                 let (stream, addr) = result?;
                 log::info!("[{:?}] New connection", addr);
 
-                // TODO: There could be an unavailable local device before a legitimate one, this should
-                // get the first device that returns a valid transport::Hub
+                // Find a suitable device to forward this client to
                 let device = {
-                    let mut devices = app
-                        .device_manager
-                        .as_ref()
-                        .ok_or(MiniDSPError::TransportClosed)?
-                        .devices();
-
-                    if let Some(serial) = cfg.device_serial {
-                        devices.into_iter().find(|dev| dev.device_info().map(|di| di.serial == serial).unwrap_or(false))
-                    } else if let Some(device_index) = cfg.device_index {
-                        devices.into_iter().nth(device_index)
-                    } else {
-                        devices.sort_by_key(|dev| !dev.is_local());
-                        devices.into_iter().next()
-                    }
+                    let cfg = cfg.clone();
+                    tokio::task::spawn_blocking(move || device_matches(&cfg).ok()).await.unwrap()
                 };
 
                 log::info!("[{:?}] New connection assiged to {}",
@@ -146,7 +151,6 @@ pub async fn main(cfg: config::TcpServer) -> Result<(), MiniDSPError> {
                     device.as_ref().map(|dev| dev.url.clone()).unwrap_or_else(|| "(no devices found)".to_string())
                 );
 
-                // Find a suitable device to forward this client to
                 if let Some(hub) = device.and_then(|dev| dev.to_hub()) {
                     tokio::spawn(async move {
                         let result = forward(stream, Box::pin(hub)).await;
@@ -161,4 +165,31 @@ pub async fn main(cfg: config::TcpServer) -> Result<(), MiniDSPError> {
            },
         }
     }
+}
+
+fn device_matches(cfg: &config::TcpServer) -> Result<Arc<Device>> {
+    let app = super::APP.get().unwrap();
+    let app = app.blocking_read();
+    let device = {
+        let mut devices = app
+            .device_manager
+            .as_ref()
+            .ok_or(MiniDSPError::TransportClosed)?
+            .devices();
+
+        if let Some(serial) = cfg.device_serial {
+            devices.into_iter().find(|dev| {
+                dev.device_info()
+                    .map(|di| di.serial == serial)
+                    .unwrap_or(false)
+            })
+        } else if let Some(device_index) = cfg.device_index {
+            devices.into_iter().nth(device_index)
+        } else {
+            devices.sort_by_key(|dev| !dev.is_local());
+            devices.into_iter().next()
+        }
+    };
+
+    device.ok_or_else(|| anyhow::anyhow!("no matching devices found"))
 }

--- a/devtools/Cargo.toml
+++ b/devtools/Cargo.toml
@@ -11,20 +11,20 @@ symbols = ["minidsp/device"]
 devices = ["minidsp/devices"]
 
 [dependencies]
-anyhow = "1.0.65"
+anyhow = "1.0.66"
 bimap = "0.6.2"
-clap = "4.0.11"
+clap = "4.0.18"
 env_logger = "0.9.1"
-futures = "0.3.24"
-futures-sink = "0.3.24"
-futures-util = "0.3.24"
+futures = "0.3.25"
+futures-sink = "0.3.25"
+futures-util = "0.3.25"
 minidsp = {path = "../minidsp", version="0.1.4", default-features = false, features = []}
 strong-xml = "0.6.3"
 termcolor = "1.1.3"
 
 # Codegen
 Inflector = "0.11.4"
-proc-macro2 = "1.0.46"
+proc-macro2 = "1.0.47"
 quote = "1.0.21"
 
 [dependencies.tokio]

--- a/devtools/Cargo.toml
+++ b/devtools/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["Mathieu Rene <mathieu.rene@gmail.com>"]
 edition = "2021"
 name = "minidsp-devtools"
-version = "0.1.7"
+version = "0.1.8"
 license = "Apache-2.0"
 
 [features]

--- a/docs/config.example.toml
+++ b/docs/config.example.toml
@@ -3,6 +3,11 @@
 #
 # A default HTTP server is exposed via a unix socket at /tmp/minidsp.sock
 
+# If set, the daemon will ignore network broadcasts for discovering devices, which can be inconvenient when dealing with complex multi-device setups
+# The desired remote devices can then be manually added using `[[static_device]]` sections
+# ignore_advertisements = true
+
+
 # If desired, an api can be exposed over the local network
 [http_server]
 bind_address = "127.0.0.1:5380"

--- a/docs/gen-output.sh
+++ b/docs/gen-output.sh
@@ -38,3 +38,5 @@ cli_cmd "output_crossover_help" output 0 crossover --help
 cli_cmd "output_compressor_help" output 0 compressor --help
 cli_cmd "output_mute_help" output 0 mute --help
 cli_cmd "output_peq_help" output 0 peq --help
+cli_cmd "output_gain_help" output 0 gain --help
+

--- a/docs/src/outputs.txt
+++ b/docs/src/outputs.txt
@@ -314,3 +314,15 @@ Arguments:
 Options:
   -h, --help  Print help information
 # ANCHOR_END: output_peq_help
+# ANCHOR: output_gain_help
+$ minidsp output 0 gain --help
+Set the output gain for this channel
+
+Usage: minidsp output <OUTPUT_INDEX> gain <VALUE>
+
+Arguments:
+  <VALUE>  Output gain in dB
+
+Options:
+  -h, --help  Print help information
+# ANCHOR_END: output_gain_help

--- a/docs/src/outputs.txt
+++ b/docs/src/outputs.txt
@@ -1,353 +1,316 @@
 # ANCHOR: help
 $ minidsp --help
-minidsp 0.1.5
-Mathieu Rene <mathieu.rene@gmail.com>
+Usage: minidsp [OPTIONS] [COMMAND]
 
-USAGE:
-    minidsp [OPTIONS] [SUBCOMMAND]
+Commands:
+  probe   Try to find reachable devices
+  status  Prints the master status and current levels
+  gain    Set the master output gain [-127, 0]
+  mute    Set the master mute status
+  source  Set the active input source
+  config  Set the current active configuration,
+  dirac   Sets whether Dirac Live is enabled
+  input   Control settings regarding input channels
+  output  Control settings regarding output channels
+  server  (deprecated) Launch a server usable with `--tcp`, the mobile application, and the official client
+  debug   Low-level debug utilities
+  help    Print this message or the help of the given subcommand(s)
 
-OPTIONS:
-        --all-local-devices            Apply the given commands to all matching local usb devices
-        --daemon-sock <DAEMON_SOCK>    Discover devices that are managed by the local instance of
-                                       minidspd [env: MINIDSP_SOCK=]
-        --daemon-url <DAEMON_URL>      Discover devices that are managed by the remote instance of
-                                       minidspd [env: MINIDSPD_URL=]
-    -f <FILE>                          Read commands to run from the given filename (use - for
-                                       stdin)
-        --force-kind <force-kind>      Force the device to a specific product instead of probing its
-                                       hardware id. May break things, use at your own risk
-    -h, --help                         Print help information
-        --log <LOG>                    Log commands and responses to a file [env: MINIDSP_LOG=]
-    -o, --output <OUTPUT_FORMAT>       Output response format (text (default), json, jsonline)
-                                       [default: text]
-        --tcp <tcp>                    The target address of the server component [env:
-                                       MINIDSP_TCP=]
-        --url <URL>                    Directly connect to this transport url [env: MINIDSP_URL=]
-        --usb <usb>                    The USB vendor and product id (2752:0011 for the 2x4HD) [env:
-                                       MINIDSP_USB=]
-    -v, --verbose                      Verbosity level. -v display decoded commands and responses
-                                       -vv display decoded commands including readfloats -vvv
-                                       display hex data frames
-    -V, --version                      Print version information
-
-SUBCOMMANDS:
-    config    Set the current active configuration,
-    debug     Low-level debug utilities
-    dirac     Sets whether Dirac Live is enabled
-    gain      Set the master output gain [-127, 0]
-    help      Print this message or the help of the given subcommand(s)
-    input     Control settings regarding input channels
-    mute      Set the master mute status
-    output    Control settings regarding output channels
-    probe     Try to find reachable devices
-    server    (deprecated) Launch a server usable with `--tcp`, the mobile application, and the
-                  official client
-    source    Set the active input source
-    status    Prints the master status and current levels
+Options:
+  -v, --verbose...
+          Verbosity level. -v display decoded commands and responses -vv display decoded commands including readfloats -vvv display hex data frames
+  -o, --output <OUTPUT_FORMAT>
+          Output response format (text (default), json, jsonline) [default: text]
+      --log <LOG>
+          Log commands and responses to a file [env: MINIDSP_LOG=]
+      --all-local-devices
+          Apply the given commands to all matching local usb devices
+  -d, --device-index <device-index>
+          Use the given device 0-based index (use minidsp probe for a list of available devices) [env: MINIDSP_INDEX=]
+      --usb <usb>
+          The USB vendor and product id (2752:0011 for the 2x4HD) [env: MINIDSP_USB=]
+      --tcp <tcp>
+          The target address of the server component [env: MINIDSP_TCP=]
+      --force-kind <force-kind>
+          Force the device to a specific product instead of probing its hardware id. May break things, use at your own risk
+      --url <URL>
+          Directly connect to this transport url [env: MINIDSP_URL=]
+      --daemon-url <DAEMON_URL>
+          Discover devices that are managed by the remote instance of minidspd [env: MINIDSPD_URL=]
+      --daemon-sock <DAEMON_SOCK>
+          Discover devices that are managed by the local instance of minidspd [env: MINIDSP_SOCK=]
+  -f <FILE>
+          Read commands to run from the given filename (use - for stdin)
+  -h, --help
+          Print help information
+  -V, --version
+          Print version information
 # ANCHOR_END: help
 # ANCHOR: config_help
 $ minidsp config --help
-minidsp-config 
 Set the current active configuration,
 
-USAGE:
-    minidsp config <VALUE>
+Usage: minidsp config <VALUE>
 
-ARGS:
-    <VALUE>    0-indexed configuation preset value (0, 1, 2, 3)
+Arguments:
+  <VALUE>  0-indexed configuation preset value (0, 1, 2, 3)
 
-OPTIONS:
-    -h, --help    Print help information
+Options:
+  -h, --help  Print help information
 # ANCHOR_END: config_help
 # ANCHOR: gain_help
 $ minidsp gain --help
-minidsp-gain 
 Set the master output gain [-127, 0]
 
-USAGE:
-    minidsp gain [OPTIONS] <VALUE>
+Usage: minidsp gain [OPTIONS] <VALUE>
 
-ARGS:
-    <VALUE>    Gain in decibels, between -127 and 0 inclusively
+Arguments:
+  <VALUE>  Gain in decibels, between -127 and 0 inclusively
 
-OPTIONS:
-    -h, --help        Print help information
-    -r, --relative    Specify the value as a relative increment on top of the current gain
+Options:
+  -r, --relative  Specify the value as a relative increment on top of the current gain
+  -h, --help      Print help information
 # ANCHOR_END: gain_help
 # ANCHOR: mute_help
 $ minidsp mute --help
-minidsp-mute 
 Set the master mute status
 
-USAGE:
-    minidsp mute <VALUE>
+Usage: minidsp mute <VALUE>
 
-ARGS:
-    <VALUE>    on, off, toggle
+Arguments:
+  <VALUE>  on, off, toggle
 
-OPTIONS:
-    -h, --help    Print help information
+Options:
+  -h, --help  Print help information
 # ANCHOR_END: mute_help
 # ANCHOR: source_help
 $ minidsp source --help
-minidsp-source 
 Set the active input source
 
-USAGE:
-    minidsp source <VALUE>
+Usage: minidsp source <VALUE>
 
-ARGS:
-    <VALUE>    The source to use: analog, toslink, spdif, usb, aesebu, rca, xlr, lan, i2s,
-               bluetooth
+Arguments:
+  <VALUE>  The source to use: analog, toslink, spdif, usb, aesebu, rca, xlr, lan, i2s, bluetooth
 
-OPTIONS:
-    -h, --help    Print help information
+Options:
+  -h, --help  Print help information
 # ANCHOR_END: source_help
 # ANCHOR: dirac_help
 $ minidsp dirac --help
-minidsp-dirac 
 Sets whether Dirac Live is enabled
 
-USAGE:
-    minidsp dirac <VALUE>
+Usage: minidsp dirac <VALUE>
 
-ARGS:
-    <VALUE>    on, off, toggle
+Arguments:
+  <VALUE>  on, off, toggle
 
-OPTIONS:
-    -h, --help    Print help information
+Options:
+  -h, --help  Print help information
 # ANCHOR_END: dirac_help
 # ANCHOR: input_help
 $ minidsp input --help
-minidsp-input 
 Control settings regarding input channels
 
-USAGE:
-    minidsp input <INPUT_INDEX> <SUBCOMMAND>
+Usage: minidsp input <INPUT_INDEX> <COMMAND>
 
-ARGS:
-    <INPUT_INDEX>    Index of the input channel, starting at 0
+Commands:
+  gain     Set the input gain for this channel
+  mute     Set the master mute status
+  routing  Controls signal routing from this input
+  peq      Control the parametric equalizer
+  help     Print this message or the help of the given subcommand(s)
 
-OPTIONS:
-    -h, --help    Print help information
+Arguments:
+  <INPUT_INDEX>  Index of the input channel, starting at 0
 
-SUBCOMMANDS:
-    gain       Set the input gain for this channel
-    help       Print this message or the help of the given subcommand(s)
-    mute       Set the master mute status
-    peq        Control the parametric equalizer
-    routing    Controls signal routing from this input
+Options:
+  -h, --help  Print help information
 # ANCHOR_END: input_help
 # ANCHOR: input_gain_help
 $ minidsp input 0 gain --help
-minidsp-input-gain 
 Set the input gain for this channel
 
-USAGE:
-    minidsp input <INPUT_INDEX> gain <VALUE>
+Usage: minidsp input <INPUT_INDEX> gain <VALUE>
 
-ARGS:
-    <VALUE>    Gain in dB
+Arguments:
+  <VALUE>  Gain in dB
 
-OPTIONS:
-    -h, --help    Print help information
+Options:
+  -h, --help  Print help information
 # ANCHOR_END: input_gain_help
 # ANCHOR: input_mute_help
 $ minidsp input 0 mute --help
-minidsp-input-mute 
 Set the master mute status
 
-USAGE:
-    minidsp input <INPUT_INDEX> mute <VALUE>
+Usage: minidsp input <INPUT_INDEX> mute [VALUE]
 
-ARGS:
-    <VALUE>    on | off
+Arguments:
+  [VALUE]  on | off
 
-OPTIONS:
-    -h, --help    Print help information
+Options:
+  -h, --help  Print help information
 # ANCHOR_END: input_mute_help
 # ANCHOR: input_peq_help
 $ minidsp input 0 peq --help
-minidsp-input-peq 
 Control the parametric equalizer
 
-USAGE:
-    minidsp input <INPUT_INDEX> peq <INDEX> <SUBCOMMAND>
+Usage: minidsp input <INPUT_INDEX> peq <INDEX> <COMMAND>
 
-ARGS:
-    <INDEX>    Parametric EQ index (all | <id>) (0 to 9 inclusively)
+Commands:
+  set     Set coefficients
+  bypass  Sets the bypass toggle
+  clear   Sets all coefficients back to their default values and un-bypass them
+  import  Imports the coefficients from the given file
+  help    Print this message or the help of the given subcommand(s)
 
-OPTIONS:
-    -h, --help    Print help information
+Arguments:
+  <INDEX>  Parametric EQ index (all | <id>) (0 to 9 inclusively)
 
-SUBCOMMANDS:
-    bypass    Sets the bypass toggle
-    clear     Sets all coefficients back to their default values and un-bypass them
-    help      Print this message or the help of the given subcommand(s)
-    import    Imports the coefficients from the given file
-    set       Set coefficients
+Options:
+  -h, --help  Print help information
 # ANCHOR_END: input_peq_help
 # ANCHOR: input_routing_help
 $ minidsp input 0 routing --help
-minidsp-input-routing 
 Controls signal routing from this input
 
-USAGE:
-    minidsp input <INPUT_INDEX> routing <OUTPUT_INDEX> <SUBCOMMAND>
+Usage: minidsp input <INPUT_INDEX> routing <OUTPUT_INDEX> <COMMAND>
 
-ARGS:
-    <OUTPUT_INDEX>    Index of the output channel starting at 0
+Commands:
+  enable  Controls whether the output matrix for this input is enabled for the given output index
+  gain    
+  help    Print this message or the help of the given subcommand(s)
 
-OPTIONS:
-    -h, --help    Print help information
+Arguments:
+  <OUTPUT_INDEX>  Index of the output channel starting at 0
 
-SUBCOMMANDS:
-    enable    Controls whether the output matrix for this input is enabled for the given output
-                  index
-    gain      
-    help      Print this message or the help of the given subcommand(s)
+Options:
+  -h, --help  Print help information
 # ANCHOR_END: input_routing_help
 # ANCHOR: output_help
 $ minidsp output --help
-minidsp-output 
 Control settings regarding output channels
 
-USAGE:
-    minidsp output <OUTPUT_INDEX> <SUBCOMMAND>
+Usage: minidsp output <OUTPUT_INDEX> <COMMAND>
 
-ARGS:
-    <OUTPUT_INDEX>    Index of the output channel, starting at 0
+Commands:
+  gain        Set the output gain for this channel
+  mute        Set the master mute status
+  delay       Set the delay associated to this channel
+  invert      Set phase inversion on this channel
+  peq         Control the parametric equalizer
+  fir         Control the FIR filter
+  crossover   Control crossovers (2x 4 biquads)
+  compressor  Control the compressor
+  help        Print this message or the help of the given subcommand(s)
 
-OPTIONS:
-    -h, --help    Print help information
+Arguments:
+  <OUTPUT_INDEX>  Index of the output channel, starting at 0
 
-SUBCOMMANDS:
-    compressor    Control the compressor
-    crossover     Control crossovers (2x 4 biquads)
-    delay         Set the delay associated to this channel
-    fir           Control the FIR filter
-    gain          Set the output gain for this channel
-    help          Print this message or the help of the given subcommand(s)
-    invert        Set phase inversion on this channel
-    mute          Set the master mute status
-    peq           Control the parametric equalizer
+Options:
+  -h, --help  Print help information
 # ANCHOR_END: output_help
 # ANCHOR: output_delay_help
 $ minidsp output 0 delay --help
-minidsp-output-delay 
 Set the delay associated to this channel
 
-USAGE:
-    minidsp output <OUTPUT_INDEX> delay <DELAY>
+Usage: minidsp output <OUTPUT_INDEX> delay <DELAY>
 
-ARGS:
-    <DELAY>    Delay in milliseconds
+Arguments:
+  <DELAY>  Delay in milliseconds
 
-OPTIONS:
-    -h, --help    Print help information
+Options:
+  -h, --help  Print help information
 # ANCHOR_END: output_delay_help
 # ANCHOR: output_fir_help
 $ minidsp output 0 fir --help
-minidsp-output-fir 
 Control the FIR filter
 
-USAGE:
-    minidsp output <OUTPUT_INDEX> fir <SUBCOMMAND>
+Usage: minidsp output <OUTPUT_INDEX> fir <COMMAND>
 
-OPTIONS:
-    -h, --help    Print help information
+Commands:
+  set     Set coefficients
+  bypass  Sets the bypass toggle
+  clear   Sets all coefficients back to their default values and un-bypass them
+  import  Imports the coefficients from the given file
+  help    Print this message or the help of the given subcommand(s)
 
-SUBCOMMANDS:
-    bypass    Sets the bypass toggle
-    clear     Sets all coefficients back to their default values and un-bypass them
-    help      Print this message or the help of the given subcommand(s)
-    import    Imports the coefficients from the given file
-    set       Set coefficients
+Options:
+  -h, --help  Print help information
 # ANCHOR_END: output_fir_help
 # ANCHOR: output_invert_help
 $ minidsp output 0 invert --help
-minidsp-output-invert 
 Set phase inversion on this channel
 
-USAGE:
-    minidsp output <OUTPUT_INDEX> invert <VALUE>
+Usage: minidsp output <OUTPUT_INDEX> invert [VALUE]
 
-ARGS:
-    <VALUE>    on | off
+Arguments:
+  [VALUE]  on | off
 
-OPTIONS:
-    -h, --help    Print help information
+Options:
+  -h, --help  Print help information
 # ANCHOR_END: output_invert_help
 # ANCHOR: output_crossover_help
 $ minidsp output 0 crossover --help
-minidsp-output-crossover 
 Control crossovers (2x 4 biquads)
 
-USAGE:
-    minidsp output <OUTPUT_INDEX> crossover <GROUP> <INDEX> <SUBCOMMAND>
+Usage: minidsp output <OUTPUT_INDEX> crossover <GROUP> <INDEX> <COMMAND>
 
-ARGS:
-    <GROUP>    Group index (0 or 1)
-    <INDEX>    Filter index (all | 0 | 1 | 3)
+Commands:
+  set     Set coefficients
+  bypass  Sets the bypass toggle
+  clear   Sets all coefficients back to their default values and un-bypass them
+  import  Imports the coefficients from the given file
+  help    Print this message or the help of the given subcommand(s)
 
-OPTIONS:
-    -h, --help    Print help information
+Arguments:
+  <GROUP>  Group index (0 or 1)
+  <INDEX>  Filter index (all | 0 | 1 | 3)
 
-SUBCOMMANDS:
-    bypass    Sets the bypass toggle
-    clear     Sets all coefficients back to their default values and un-bypass them
-    help      Print this message or the help of the given subcommand(s)
-    import    Imports the coefficients from the given file
-    set       Set coefficients
+Options:
+  -h, --help  Print help information
 # ANCHOR_END: output_crossover_help
 # ANCHOR: output_compressor_help
 $ minidsp output 0 compressor --help
-minidsp-output-compressor 
 Control the compressor
 
-USAGE:
-    minidsp output <OUTPUT_INDEX> compressor [OPTIONS]
+Usage: minidsp output <OUTPUT_INDEX> compressor [OPTIONS]
 
-OPTIONS:
-    -a, --attack <ATTACK>          Sets the attack time in ms
-    -b, --bypass <BYPASS>          Bypasses the compressor (on | off)
-    -h, --help                     Print help information
-    -k, --ratio <RATIO>            Sets the ratio
-    -r, --release <RELEASE>        Sets the release time in ms
-    -t, --threshold <THRESHOLD>    Sets the threshold in dBFS
+Options:
+  -b, --bypass <BYPASS>        Bypasses the compressor (on | off)
+  -t, --threshold <THRESHOLD>  Sets the threshold in dBFS
+  -k, --ratio <RATIO>          Sets the ratio
+  -a, --attack <ATTACK>        Sets the attack time in ms
+  -r, --release <RELEASE>      Sets the release time in ms
+  -h, --help                   Print help information
 # ANCHOR_END: output_compressor_help
 # ANCHOR: output_mute_help
 $ minidsp output 0 mute --help
-minidsp-output-mute 
 Set the master mute status
 
-USAGE:
-    minidsp output <OUTPUT_INDEX> mute <VALUE>
+Usage: minidsp output <OUTPUT_INDEX> mute [VALUE]
 
-ARGS:
-    <VALUE>    on | off
+Arguments:
+  [VALUE]  on | off
 
-OPTIONS:
-    -h, --help    Print help information
+Options:
+  -h, --help  Print help information
 # ANCHOR_END: output_mute_help
 # ANCHOR: output_peq_help
 $ minidsp output 0 peq --help
-minidsp-output-peq 
 Control the parametric equalizer
 
-USAGE:
-    minidsp output <OUTPUT_INDEX> peq <INDEX> <SUBCOMMAND>
+Usage: minidsp output <OUTPUT_INDEX> peq <INDEX> <COMMAND>
 
-ARGS:
-    <INDEX>    Parametric EQ index (all | <id>) (0 to 9 inclusively)
+Commands:
+  set     Set coefficients
+  bypass  Sets the bypass toggle
+  clear   Sets all coefficients back to their default values and un-bypass them
+  import  Imports the coefficients from the given file
+  help    Print this message or the help of the given subcommand(s)
 
-OPTIONS:
-    -h, --help    Print help information
+Arguments:
+  <INDEX>  Parametric EQ index (all | <id>) (0 to 9 inclusively)
 
-SUBCOMMANDS:
-    bypass    Sets the bypass toggle
-    clear     Sets all coefficients back to their default values and un-bypass them
-    help      Print this message or the help of the given subcommand(s)
-    import    Imports the coefficients from the given file
-    set       Set coefficients
+Options:
+  -h, --help  Print help information
 # ANCHOR_END: output_peq_help

--- a/minidsp/Cargo.toml
+++ b/minidsp/Cargo.toml
@@ -10,16 +10,16 @@ repository = "https://github.com/mrene/minidsp-rs"
 version = "0.1.8"
 
 [dependencies]
-anyhow = "1.0.65"
-async-trait = "0.1.57"
+anyhow = "1.0.66"
+async-trait = "0.1.58"
 atomic_refcell = "0.1.8"
 bimap = "0.6.2"
 bytes = "1.2.1"
-clap = { version = "4.0.11", features = ["derive", "env"] }
+clap = { version = "4.0.18", features = ["derive", "env"] }
 env_logger = "0.9.1"
-futures = "0.3.24"
-futures-sink = "0.3.24"
-futures-util = "0.3.24"
+futures = "0.3.25"
+futures-sink = "0.3.25"
+futures-util = "0.3.25"
 hex = "0.4.3"
 hexplay = "0.2.1"
 hyper = "0.14.20"
@@ -28,14 +28,14 @@ log = "0.4.17"
 minidsp-protocol = {path = "../protocol", version = "0.1.8", default-features = false, features = ["use_serde", "debug", "devices"]}
 pin-project = "1.0.12"
 schemars = "0.8.11"
-serde = { version = "1.0.145", features = ["derive"] }
-serde_json = "1.0.85"
+serde = { version = "1.0.147", features = ["derive"] }
+serde_json = "1.0.87"
 shellwords = "1.1.0"
 strong-xml = "0.6.3"
 strum = { version = "0.24.1", features = ["derive"] }
 termcolor = "1.1.3"
 thiserror = "1.0.37"
-tokio-stream = { version = "0.1.10", features = ["sync"] }
+tokio-stream = { version = "0.1.11", features = ["sync"] }
 tokio-tungstenite = "0.17.2"
 tower = { version = "0.4.13", features = ["util", "timeout"] }
 url2 = "0.0.6"

--- a/minidsp/Cargo.toml
+++ b/minidsp/Cargo.toml
@@ -7,7 +7,7 @@ keywords = ["minidsp", "audio", "dsp"]
 license = "Apache-2.0"
 name = "minidsp"
 repository = "https://github.com/mrene/minidsp-rs"
-version = "0.1.7"
+version = "0.1.8"
 
 [dependencies]
 anyhow = "1.0.65"
@@ -25,7 +25,7 @@ hexplay = "0.2.1"
 hyper = "0.14.20"
 lazy_static = "1.4.0"
 log = "0.4.17"
-minidsp-protocol = {path = "../protocol", version = "0.1.7", default-features = false, features = ["use_serde", "debug", "devices"]}
+minidsp-protocol = {path = "../protocol", version = "0.1.8", default-features = false, features = ["use_serde", "debug", "devices"]}
 pin-project = "1.0.12"
 schemars = "0.8.11"
 serde = { version = "1.0.145", features = ["derive"] }
@@ -84,6 +84,7 @@ assets = [
   ["../debian/minidsp.service", "lib/systemd/system/minidsp.service", "644"],
   ["../debian/minidsp.udev", "lib/udev/rules.d/99-minidsp.rules", "644"],
 ]
+conf-files = ["etc/minidsp/config.toml"]
 copyright = "2021, Mathieu Rene <mathieu.rene@gmail.com>"
 depends = "libusb-1.0-0 (>= 2:1.0.21), libc6 (>= 2.17), libudev1 (>= 183)"
 extended-description = """\

--- a/minidsp/src/bin/minidsp/handlers.rs
+++ b/minidsp/src/bin/minidsp/handlers.rs
@@ -1,4 +1,4 @@
-use std::{net::ToSocketAddrs, str::FromStr, time::Duration};
+use std::{str::FromStr, time::Duration};
 
 use minidsp::{
     formats::{rew::FromRew, wav::read_wav_filter},
@@ -45,12 +45,10 @@ pub(crate) async fn run_server(
                 return Err(anyhow::anyhow!("--ip is required if --advertise is used"));
             }
             let interval = Duration::from_secs(1);
-            let bind_addr = bind_address.to_socket_addrs()?.next().ok_or_else(|| {
-                anyhow::anyhow!("bind adddress didn't resolve to a usable address")
-            })?;
-            dbg!(&packet);
             tokio::spawn(discovery::server::advertise_packet(
-                bind_addr, packet, interval,
+                None,
+                move || Some(packet.clone()),
+                interval,
             ));
         }
         use crate::tcp_server;

--- a/minidsp/src/bin/minidsp/main.rs
+++ b/minidsp/src/bin/minidsp/main.rs
@@ -522,14 +522,19 @@ async fn main() -> Result<()> {
     if let Some(SubCommand::Server { .. }) = opts.subcmd {
         log::warn!("The `server` command is deprecated and will be removed in a future release. Use `minidspd` instead.");
 
-        let transport = devices
-            .first()
-            .ok_or_else(|| anyhow!("No devices found"))?
+        let device = devices.first().ok_or_else(|| anyhow!("No devices found"))?;
+
+        let transport = device
             .transport
             .try_clone()
             .expect("device has disappeared");
 
-        run_server(opts.subcmd.unwrap(), Box::pin(transport)).await?;
+        run_server(
+            opts.subcmd.unwrap(),
+            Box::pin(transport),
+            device.device_info,
+        )
+        .await?;
         return Ok(());
     }
 

--- a/minidsp/src/client.rs
+++ b/minidsp/src/client.rs
@@ -68,7 +68,9 @@ impl Client {
         let dsp_version_view = self.read_memory(eeprom::FIRMWARE_VERSION, 1).await?;
         let serial_view = self.read_memory(eeprom::SERIAL_SHORT, 2).await?;
         let info = DeviceInfo {
-            hw_id,
+            hw_id: hw_id.hw_id,
+            fw_major: hw_id.fw_major,
+            fw_minor: hw_id.fw_minor,
             dsp_version: dsp_version_view.read_u8(eeprom::FIRMWARE_VERSION).unwrap(),
             serial: 900000 + (serial_view.read_u16(eeprom::SERIAL_SHORT).unwrap() as u32),
         };

--- a/minidsp/src/transport/mock/mod.rs
+++ b/minidsp/src/transport/mock/mod.rs
@@ -31,6 +31,8 @@ impl MockTransport {
             dsp_version,
             hw_id,
             serial: 0,
+            fw_major: 1,
+            fw_minor: 13,
         });
         let device: Arc<Mutex<MockDevice>> =
             Arc::new(Mutex::new(MockDevice::new(hw_id, dsp_version, kind)));

--- a/minidsp/src/transport/multiplexer.rs
+++ b/minidsp/src/transport/multiplexer.rs
@@ -189,11 +189,12 @@ impl std::ops::Deref for MultiplexerService {
 
 #[cfg(test)]
 mod test {
-    use bytes::Bytes;
+    
     use futures::channel::mpsc;
+    use minidsp_protocol::HardwareId;
 
     use super::*;
-    use crate::commands::BytesWrap;
+    
 
     #[tokio::test]
     async fn test_golden_path() {
@@ -212,9 +213,11 @@ mod test {
             let cmd = sink_rx.next().await.unwrap();
             assert!(matches!(cmd, Commands::ReadHardwareId { .. }));
             stream_tx
-                .send(Ok(Responses::HardwareId {
-                    payload: BytesWrap(Bytes::from_static(b"allo")),
-                }))
+                .send(Ok(Responses::HardwareId(HardwareId{
+                    fw_major: 1,
+                    fw_minor: 10,
+                    hw_id: 10,
+                })))
                 .await
                 .unwrap();
         };

--- a/minidsp/src/transport/multiplexer.rs
+++ b/minidsp/src/transport/multiplexer.rs
@@ -189,12 +189,11 @@ impl std::ops::Deref for MultiplexerService {
 
 #[cfg(test)]
 mod test {
-    
+
     use futures::channel::mpsc;
     use minidsp_protocol::HardwareId;
 
     use super::*;
-    
 
     #[tokio::test]
     async fn test_golden_path() {
@@ -213,7 +212,7 @@ mod test {
             let cmd = sink_rx.next().await.unwrap();
             assert!(matches!(cmd, Commands::ReadHardwareId { .. }));
             stream_tx
-                .send(Ok(Responses::HardwareId(HardwareId{
+                .send(Ok(Responses::HardwareId(HardwareId {
                     fw_major: 1,
                     fw_minor: 10,
                     hw_id: 10,

--- a/minidsp/src/transport/net/discovery/mod.rs
+++ b/minidsp/src/transport/net/discovery/mod.rs
@@ -16,8 +16,10 @@ pub struct DiscoveryPacket {
     pub mac_address: [u8; 6],
     pub ip_address: Ipv4Addr,
     pub hwid: u8,
-    pub typ: u8,
+    pub dsp_id: u8,
     pub sn: u16,
+    pub fw_major: u8,
+    pub fw_minor: u8,
     pub hostname: String,
 }
 
@@ -35,8 +37,10 @@ impl DiscoveryPacket {
         let ip_array: [u8; 4] = packet[14..18].try_into().unwrap();
         let p = DiscoveryPacket {
             hwid: packet[18],
-            typ: packet[21],
+            dsp_id: packet[21],
             sn: ((packet[22] as u16) << 8) | (packet[23] as u16),
+            fw_major: packet[19],
+            fw_minor: packet[20],
             ip_address: Ipv4Addr::from(ip_array),
             mac_address: packet[6..12].try_into().unwrap(),
             hostname: String::from_utf8_lossy(&packet[36..36 + packet[35] as usize]).to_string(),
@@ -54,7 +58,9 @@ impl DiscoveryPacket {
             .as_ref()
             .copy_to_slice(&mut p[14..18]);
         p[18] = self.hwid;
-        p[21] = self.typ;
+        p[19] = self.fw_major;
+        p[20] = self.fw_minor;
+        p[21] = self.dsp_id;
         p[22] = (self.sn >> 8) as u8;
         p[23] = (self.sn & 0xFF) as u8;
         if self.hostname.len() > u8::MAX as usize {
@@ -109,8 +115,10 @@ mod test {
             mac_address: [10, 20, 30, 40, 50, 60],
             ip_address: Ipv4Addr::new(192, 168, 1, 100),
             hwid: 222,
-            typ: 51,
+            dsp_id: 51,
             sn: 1234,
+            fw_major: 1,
+            fw_minor: 2,
             hostname: "Living room TV".to_string(),
         };
 

--- a/minidsp/src/transport/net/discovery/server.rs
+++ b/minidsp/src/transport/net/discovery/server.rs
@@ -10,7 +10,11 @@ use tokio::{
 use super::{DiscoveryPacket, DISCOVERY_PORT};
 
 /// Advertises the given discovery packet at a specified interval
-pub async fn advertise_packet(bind_addr: SocketAddr, packet: DiscoveryPacket, interval: Duration) -> Result<()> {
+pub async fn advertise_packet(
+    bind_addr: SocketAddr,
+    packet: DiscoveryPacket,
+    interval: Duration,
+) -> Result<()> {
     let socket = UdpSocket::bind(bind_addr).await?;
     socket.set_broadcast(true)?;
 

--- a/minidsp/src/transport/net/discovery/server.rs
+++ b/minidsp/src/transport/net/discovery/server.rs
@@ -1,4 +1,7 @@
-use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use std::{
+    net::{IpAddr, Ipv4Addr, SocketAddr},
+    sync::Arc,
+};
 
 use anyhow::Result;
 use log::{error, trace};
@@ -11,25 +14,32 @@ use super::{DiscoveryPacket, DISCOVERY_PORT};
 
 /// Advertises the given discovery packet at a specified interval
 pub async fn advertise_packet(
-    bind_addr: SocketAddr,
-    packet: DiscoveryPacket,
+    bind_addr: Option<SocketAddr>,
+    packet: impl Fn() -> Option<DiscoveryPacket> + Send + Sync + 'static,
     interval: Duration,
 ) -> Result<()> {
+    let bind_addr =
+        bind_addr.unwrap_or_else(|| SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), 0));
     let socket = UdpSocket::bind(bind_addr).await?;
     socket.set_broadcast(true)?;
 
     let target_address = SocketAddr::new(IpAddr::V4(Ipv4Addr::BROADCAST), DISCOVERY_PORT);
     socket.connect(target_address).await?;
 
-    let packet_bytes = packet.to_bytes();
+    let packet = Arc::new(packet);
     loop {
-        let send_result = socket.send(packet_bytes.as_ref()).await;
-        match send_result {
-            Ok(_) => {
-                trace!("sent advertisement: {:?}", &packet);
-            }
-            Err(e) => {
-                error!("couldn't send broadcast datagram: {:?}", e);
+        let packet = packet.clone();
+        let packet = tokio::task::spawn_blocking(move || packet()).await.unwrap();
+        if let Some(packet) = packet {
+            let packet_bytes = packet.to_bytes();
+            let send_result = socket.send(packet_bytes.as_ref()).await;
+            match send_result {
+                Ok(_) => {
+                    trace!("sent advertisement: {:?}", &packet);
+                }
+                Err(e) => {
+                    error!("couldn't send broadcast datagram: {:?}", e);
+                }
             }
         }
         sleep(interval).await;

--- a/minidsp/src/transport/net/discovery/server.rs
+++ b/minidsp/src/transport/net/discovery/server.rs
@@ -10,8 +10,8 @@ use tokio::{
 use super::{DiscoveryPacket, DISCOVERY_PORT};
 
 /// Advertises the given discovery packet at a specified interval
-pub async fn advertise_packet(packet: DiscoveryPacket, interval: Duration) -> Result<()> {
-    let socket = UdpSocket::bind(SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), 0u16)).await?;
+pub async fn advertise_packet(bind_addr: SocketAddr, packet: DiscoveryPacket, interval: Duration) -> Result<()> {
+    let socket = UdpSocket::bind(bind_addr).await?;
     socket.set_broadcast(true)?;
 
     let target_address = SocketAddr::new(IpAddr::V4(Ipv4Addr::BROADCAST), DISCOVERY_PORT);

--- a/minidsp/src/utils/mock_device.rs
+++ b/minidsp/src/utils/mock_device.rs
@@ -123,7 +123,7 @@ impl MockDevice {
     // the internal state.
     pub fn execute(&mut self, cmd: &Commands) -> Responses {
         match cmd {
-            Commands::ReadHardwareId => Responses::HardwareId(HardwareId{
+            Commands::ReadHardwareId => Responses::HardwareId(HardwareId {
                 fw_major: self.firmware_version.0,
                 fw_minor: self.firmware_version.1,
                 hw_id: self.hw_id,

--- a/minidsp/src/utils/mock_device.rs
+++ b/minidsp/src/utils/mock_device.rs
@@ -2,11 +2,11 @@
 
 use std::convert::TryInto;
 
-use bytes::{Buf, BufMut, BytesMut};
+use bytes::{Buf, BytesMut};
 use minidsp_protocol::{
-    commands::{BytesWrap, FloatView, MemoryView, Responses, Value},
+    commands::{FloatView, MemoryView, Responses, Value},
     device::{Device, DeviceKind},
-    eeprom, Commands, FixedPoint,
+    eeprom, Commands, FixedPoint, HardwareId,
 };
 
 pub struct MockDevice {
@@ -123,15 +123,11 @@ impl MockDevice {
     // the internal state.
     pub fn execute(&mut self, cmd: &Commands) -> Responses {
         match cmd {
-            Commands::ReadHardwareId => Responses::HardwareId {
-                payload: {
-                    let mut b = BytesMut::new();
-                    b.put_u8(self.firmware_version.0);
-                    b.put_u8(self.firmware_version.1);
-                    b.put_u8(self.hw_id);
-                    BytesWrap(b.freeze())
-                },
-            },
+            Commands::ReadHardwareId => Responses::HardwareId(HardwareId{
+                fw_major: self.firmware_version.0,
+                fw_minor: self.firmware_version.1,
+                hw_id: self.hw_id,
+            }),
             &Commands::ReadMemory { addr, size } => {
                 let addr = addr as usize;
                 let size = size as usize;

--- a/minidsp/tests/test_utils/mod.rs
+++ b/minidsp/tests/test_utils/mod.rs
@@ -51,6 +51,8 @@ impl TestDevice {
         let device_info = DeviceInfo {
             hw_id,
             dsp_version,
+            fw_major: 1,
+            fw_minor: 13,
             serial: 0,
         };
         let device = probe(&device_info);

--- a/protocol/Cargo.toml
+++ b/protocol/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["Mathieu Rene <mathieu.rene@gmail.com>"]
 edition = "2021"
 name = "minidsp-protocol"
-version = "0.1.7"
+version = "0.1.8"
 license = "Apache-2.0"
 description = "A control interface for some MiniDSP products"
 repository = "https://github.com/mrene/minidsp-rs"

--- a/protocol/Cargo.toml
+++ b/protocol/Cargo.toml
@@ -8,10 +8,10 @@ description = "A control interface for some MiniDSP products"
 repository = "https://github.com/mrene/minidsp-rs"
 
 [dependencies]
-anyhow = "1.0.65"
+anyhow = "1.0.66"
 bytes = "1.2.1"
 schemars = { version = "0.8.11", optional = true }
-serde = { version = "1.0.145", features = ["derive"], optional = true }
+serde = { version = "1.0.147", features = ["derive"], optional = true }
 strum = { version = "0.24.1", features = ["derive"], optional = true }
 thiserror = "1.0.37"
 

--- a/protocol/src/commands.rs
+++ b/protocol/src/commands.rs
@@ -20,7 +20,7 @@ use thiserror::Error;
 
 use super::DeviceInfo;
 use crate::{
-    eeprom, packet::ParseError, util::TryBuf, util::TryBufError, FixedPoint, MasterStatus,
+    eeprom, packet::ParseError, util::TryBuf, util::TryBufError, FixedPoint, MasterStatus, HardwareId,
 };
 
 /// Maximum number of floats that can be read in a single command
@@ -686,9 +686,7 @@ pub enum Responses {
     },
     MemoryData(MemoryView),
     FloatData(FloatView),
-    HardwareId {
-        payload: BytesWrap,
-    },
+    HardwareId(HardwareId),
     FirLoadSize {
         size: u16,
     },
@@ -726,12 +724,11 @@ impl Responses {
             },
             0x05 => Responses::MemoryData(MemoryView::from_packet(frame)?),
             0x14 => Responses::FloatData(FloatView::from_packet(frame)?),
-            0x31 => Responses::HardwareId {
-                payload: {
-                    frame.try_get_u8()?;
-                    BytesWrap(frame)
-                },
-            },
+            0x31 => Responses::HardwareId(HardwareId {
+                fw_major: frame.try_get_u8()?,
+                fw_minor: frame.try_get_u8()?,
+                hw_id: frame.try_get_u8()?,
+            }),
             0x39 => Responses::FirLoadSize {
                 size: {
                     frame.try_get_u8()?; // Consume command id
@@ -770,9 +767,11 @@ impl Responses {
                 f.put_u8(cmd_id);
                 f.put(payload.0.clone());
             }
-            Responses::HardwareId { payload } => {
+            Responses::HardwareId(hwid) => {
                 f.put_u8(0x31);
-                f.put(payload.0.clone());
+                f.put_u8(hwid.fw_major);
+                f.put_u8(hwid.fw_minor);
+                f.put_u8(hwid.hw_id);
             }
             &Responses::FirLoadSize { size } => {
                 f.put_u8(0x39);
@@ -821,10 +820,10 @@ impl Responses {
         matches!(self, Responses::HardwareId { .. })
     }
 
-    pub fn into_hardware_id(self) -> Result<u8, ProtocolError> {
+    pub fn into_hardware_id(self) -> Result<HardwareId, ProtocolError> {
         match self {
-            Responses::HardwareId { payload } => {
-                Ok(*payload.last().ok_or(ProtocolError::MalformedHardwareId)?)
+            Responses::HardwareId(id) => {
+                Ok(id)
             }
             _ => Err(ProtocolError::UnexpectedResponseType),
         }
@@ -1178,6 +1177,8 @@ mod test {
             hw_id: 10,
             dsp_version: 100,
             serial: 0,
+            fw_major: 1,
+            fw_minor: 10,
         };
         let status = MasterStatus::from_memory(&device_info, &memory).unwrap();
         assert!(status.eq(&MasterStatus {

--- a/protocol/src/lib.rs
+++ b/protocol/src/lib.rs
@@ -42,8 +42,17 @@ pub use dialect::{AddrEncoding, Dialect, FloatEncoding};
 /// Hardware id and dsp version
 pub struct DeviceInfo {
     pub hw_id: u8,
+    pub fw_major: u8,
+    pub fw_minor: u8,
     pub dsp_version: u8,
     pub serial: u32,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct HardwareId {
+    pub fw_major: u8,
+    pub fw_minor: u8,
+    pub hw_id: u8,
 }
 
 impl DeviceInfo {


### PR DESCRIPTION
- fix(discovery): add device type and firmware information to discovery packet
- fix(discovery): pull device information from discovered device info
- fix(daemon/discovery): build advertisement packets based on the device they would match. add option to disable the client side of network discovery (to prevent automatically adding remote network devices
