### PR TITLE
Reconnect device transport on timeout errors

### DIFF
--- a/daemon/src/device_manager.rs
+++ b/daemon/src/device_manager.rs
@@ -8,12 +8,7 @@ use std::{
 use anyhow::{anyhow, Result};
 use futures::{StreamExt, TryFutureExt};
 use minidsp::{
-    client::Client,
-    device::{self, probe},
-    logging,
-    transport::{self, SharedService},
-    utils::OwnedJoinHandle,
-    DeviceInfo, MiniDSP,
+    client::Client, device::{self, probe}, logging, transport::{self, SharedService}, utils::OwnedJoinHandle, DeviceInfo, MiniDSP, MiniDSPError
 };
 use tokio::sync::Mutex;
 use url2::Url2;
@@ -85,6 +80,71 @@ impl DeviceManager {
         DeviceManager { inner, handles }
     }
 
+    pub fn get_device(&self, index: usize) -> Option<Arc<Device>> {
+        let devices = self.devices();
+        let serial_match = devices.iter().find(|d| match d.device_info() {
+            Some(device_info) => device_info.serial == index as u32,
+            None => false,
+        });
+        if let Some(device) = serial_match {
+            return Some(device.clone());
+        }
+        if index >= devices.len() {
+            return None;
+        }
+        Some(devices[index].clone())
+    }
+
+    pub async fn get_minidsp(&self, index: usize) -> Option<MiniDSP<'static>> {
+        let mut attempts = 0;
+        let mut device = self.get_device(index)?;
+        loop {
+            attempts += 1;
+            let err = match device.to_minidsp() {
+                Ok(minidsp) => {
+                    let status = minidsp.get_master_status().await;
+                    if let Some(err) = status.err() {
+                        err
+                    } else {
+                        return Some(minidsp);
+                    }
+                }
+                Err(err) => err,
+            };
+            log::warn!(
+                "failed to connect to device {} (attempt {}): {}",
+                device.url,
+                attempts,
+                err
+            );
+            if attempts > 3 || !err.is_retryable() {
+                log::warn!("giving up attempting to connect.");
+                return None;
+            }
+            if err.should_reconnect() {
+                device = self.reconnect_device(device).await;
+            }
+            tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+        }
+    }
+
+    pub async fn reconnect_device(&self, device: Arc<Device>) -> Arc<Device> {
+        let url = device.url.clone();
+        {
+            let mut inner = self.inner.write().unwrap();
+            inner.devices.retain(|dev| dev.url != url);
+        }
+
+        device.shutdown().await;
+
+        let mut inner = self.inner.write().unwrap();
+        let weak_inner = Arc::downgrade(&self.inner);
+
+        let new_device: Arc<Device> = Device::new(url, weak_inner).into();
+        inner.devices.push(new_device.clone());
+        new_device
+    }
+
     pub fn register_static(&self, dev: &str) {
         let inner = self.inner.write().unwrap();
         inner.registry.register(dev, true);
@@ -145,7 +205,7 @@ pub struct Device {
     #[allow(dead_code)]
     inner: Arc<RwLock<DeviceInner>>,
     #[allow(dead_code)]
-    handles: Vec<OwnedJoinHandle<Result<(), anyhow::Error>>>,
+    handles: Mutex<Vec<OwnedJoinHandle<Result<(), anyhow::Error>>>>,
 }
 
 impl Device {
@@ -166,7 +226,36 @@ impl Device {
         Device {
             url,
             inner,
-            handles,
+            handles: Mutex::new(handles),
+        }
+    }
+
+    pub async fn shutdown(&self) {
+        {
+            let mut handles = self.handles.lock().await;
+
+            for handle in handles.iter() {
+                handle.abort();
+            }
+            for handle in handles.drain(..) {
+                if let Err(e) = handle.await {
+                    if !e.is_cancelled() {
+                        log::error!("device inner task ended with error: {}", e);
+                    }
+                }
+            }
+
+            let handle = { self.inner.write().unwrap().handle.take() };
+            match handle {
+                Some(handle) => {
+                    handle.transport.shutdown().await;
+                    let mplex = handle.service.lock().await;
+                    mplex.shutdown().await;
+                }
+                None => {
+                    log::warn!("shutting down device, but transport was already closed");
+                }
+            }
         }
     }
 
@@ -179,9 +268,14 @@ impl Device {
         inner.handle.as_ref()?.to_hub()
     }
 
-    pub fn to_minidsp(&self) -> Option<MiniDSP<'static>> {
+    pub fn to_minidsp(&self) -> Result<MiniDSP<'static>, MiniDSPError> {
         let inner = self.inner.read().unwrap();
-        inner.handle.as_ref()?.to_minidsp()
+        let result = inner
+            .handle
+            .as_ref()
+            .ok_or(MiniDSPError::DeviceNotReady)?
+            .to_minidsp();
+        result
     }
 
     pub fn device_info(&self) -> Option<DeviceInfo> {
@@ -203,7 +297,7 @@ impl Device {
         log::info!("Connecting to {}", url.as_str());
 
         // Connect to the device by url, and get a frame-level transport
-        let (mut transport, decoder) = {
+        let (mut transportlocal, decoder) = {
             let url = Url2::try_parse(url.as_str()).expect("Device::run had invalid url");
             let stream = transport::open_url(&url).await?;
 
@@ -212,13 +306,11 @@ impl Device {
             let app = app.read().await;
             let (decoder, stream) =
                 logging::transport_logging(stream, app.opts.verbose, app.opts.log.clone());
-
             (transport::Hub::new(stream), decoder)
         };
-
         // Wrap the transport into a multiplexed service for command-level multiplexing
         let service = {
-            let transport = transport
+            let transport = transportlocal
                 .try_clone()
                 .ok_or_else(|| anyhow!("transport closed prematurely"))?;
             let mplex = transport::Multiplexer::from_transport(transport);
@@ -229,13 +321,15 @@ impl Device {
         // Keep going if we do not know the device type, but it has successfully responsed to
         // probing commands. This can be used to support a common subset of features without
         // knowing the device-specific memory layout.
-        let client = Client::new(service.clone());
-        let device_info = client.get_device_info().await.ok();
+        let device_info = {
+            let client = Client::new(service.clone());
+            client.get_device_info().await.ok()
+        };
         let device_spec = device_info.map(|dev| device::probe(&dev));
 
-        let handle = DeviceHandle {
+        let devhandle = DeviceHandle {
             service,
-            transport: transport
+            transport: transportlocal
                 .try_clone()
                 .ok_or_else(|| anyhow!("transport closed prematurely"))?,
             device_spec,
@@ -260,11 +354,11 @@ impl Device {
 
         {
             let mut inner = inner.write().unwrap();
-            inner.handle.replace(handle);
+            inner.handle.replace(devhandle);
         }
 
         // Keep reading messages until the device returns an error/eof
-        while let Some(frame) = transport.next().await {
+        while let Some(frame) = transportlocal.next().await {
             if let Err(e) = frame {
                 log::warn!("Device at {} closing due to an error: {}", &url, &e);
                 break;
@@ -287,11 +381,15 @@ impl Device {
     async fn task(inner: Arc<RwLock<DeviceInner>>) -> anyhow::Result<()> {
         loop {
             // Try to probe the device until we're successful
-            if Self::task_inner(inner.clone()).await.is_ok() {
-                return Ok(());
+            let res = Self::task_inner(inner.clone()).await;
+            match res {
+                Ok(_) => return Ok(()),
+                Err(e) => {
+                    log::warn!("fail to connect: {}", e);
+                }
             }
 
-            tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+            tokio::time::sleep(std::time::Duration::from_secs(1)).await;
         }
     }
 }
@@ -318,17 +416,17 @@ pub struct DeviceHandle {
 }
 
 impl DeviceHandle {
-    pub fn to_minidsp(&self) -> Option<MiniDSP<'static>> {
+    pub fn to_minidsp(&self) -> Result<MiniDSP<'static>, MiniDSPError> {
         let client = Client::new(self.service.clone());
 
         let device_info = match self.device_info {
             Some(x) => x,
-            None => futures::executor::block_on(client.get_device_info()).ok()?,
+            None => futures::executor::block_on(client.get_device_info())?,
         };
 
         let spec = self.device_spec.unwrap_or_else(|| probe(&device_info));
         let dsp = MiniDSP::from_client(client, spec, device_info);
-        Some(dsp)
+        Ok(dsp)
     }
 
     pub fn to_hub(&self) -> Option<transport::Hub> {

--- a/daemon/src/http/mod.rs
+++ b/daemon/src/http/mod.rs
@@ -50,37 +50,20 @@ impl From<&device_manager::Device> for Device {
 }
 
 fn get_device(app: &App, index: usize) -> Result<Arc<device_manager::Device>, Error> {
-    let devices = app
-        .device_manager
+    let device_manager = app.device_manager
         .as_ref()
-        .ok_or(Error::ApplicationStillInitializing)?
-        .devices();
-
-    // Try to find a device whose serial matches the index passed as an argument
-    let serial_match = devices.iter().find(|d| match d.device_info() {
-        Some(device_info) => device_info.serial == index as u32,
-        None => false,
-    });
-
-    if let Some(device) = serial_match {
-        return Ok(device.clone());
-    }
-
-    if index >= devices.len() {
-        return Err(Error::DeviceIndexOutOfRange {
-            actual: devices.len(),
-            provided: index,
-        });
-    }
-
-    Ok(devices[index].clone())
+        .ok_or(Error::ApplicationStillInitializing)?;
+    device_manager.get_device(index).ok_or(Error::DeviceNotReady)
 }
 
-fn get_device_instance<'dsp>(app: &App, index: usize) -> Result<MiniDSP<'dsp>, Error> {
-    get_device(app, index)?
-        .to_minidsp()
-        .ok_or(Error::DeviceNotReady)
+async fn get_device_instance<'dsp>(app: &App, index: usize) -> Result<MiniDSP<'dsp>, Error> {
+    let device_manager = app.device_manager
+        .as_ref()
+        .ok_or(Error::ApplicationStillInitializing)?;
+    let minidsp = device_manager.get_minidsp(index).await;
+    minidsp.ok_or(Error::DeviceNotReady)
 }
+
 
 /// Gets a list of available devices
 async fn get_devices(req: Request<Body>) -> Result<Response<Body>, Error> {
@@ -127,7 +110,7 @@ async fn get_master_status(req: Request<Body>) -> Result<Response<Body>, Error> 
 
     let app = super::APP.get().unwrap();
     let app = app.read().await;
-    let device = get_device_instance(&app, device_index)?;
+    let device = get_device_instance(&app, device_index).await?;
     let mut status = StatusSummary::fetch(&device).await?;
     let query_levels = req.query("levels").cloned();
     let query_poll = req.query("poll").cloned();
@@ -245,7 +228,7 @@ async fn post_master_status(mut req: Request<Body>) -> Result<Response<Body>, Er
 
     let app = super::APP.get().unwrap();
     let app = app.read().await;
-    let device = get_device_instance(&app, device_index)?;
+    let device = get_device_instance(&app, device_index).await?;
 
     // Apply the requested, changes, then fetch the master status again to return it
     let status: MasterStatus = parse_body(&mut req).await?;
@@ -263,7 +246,7 @@ async fn post_config(mut req: Request<Body>) -> Result<Response<Body>, Error> {
     let device_index: usize = parse_param(&req, "deviceIndex")?;
     let app = super::APP.get().unwrap();
     let app = app.read().await;
-    let device = get_device_instance(&app, device_index)?;
+    let device = get_device_instance(&app, device_index).await?;
 
     let config: Config = parse_body(&mut req).await?;
     config.apply(&device).await?;

--- a/minidsp/src/transport/hid/stream.rs
+++ b/minidsp/src/transport/hid/stream.rs
@@ -12,7 +12,7 @@ use futures::{
     Future, FutureExt, Sink, Stream,
 };
 use hidapi::{HidDevice, HidError};
-use pin_project::pin_project;
+use pin_project::{pin_project, pinned_drop};
 
 use super::wrapper::HidDeviceWrapper;
 
@@ -22,7 +22,7 @@ const HID_PACKET_SIZE: usize = 65;
 type SendFuture = Box<dyn Future<Output = Result<(), HidError>> + Send>;
 
 /// A stream of HID reports
-#[pin_project]
+#[pin_project(PinnedDrop)]
 pub struct HidStream {
     device: Arc<HidDeviceWrapper>,
 
@@ -120,6 +120,13 @@ impl Stream for HidStream {
 
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         self.project().rx.poll_next(cx)
+    }
+}
+
+#[pinned_drop]
+impl PinnedDrop for HidStream {
+    fn drop(self: Pin<&mut Self>) {
+        self.project().rx.close();
     }
 }
 

--- a/minidsp/src/transport/hub.rs
+++ b/minidsp/src/transport/hub.rs
@@ -2,12 +2,12 @@
 
 use std::{
     pin::Pin,
-    sync::{Arc, Mutex},
+    sync::{Arc, Mutex, RwLock},
     task::{Context, Poll},
 };
 
 use bytes::Bytes;
-use futures::{channel::mpsc, Sink, SinkExt, Stream, StreamExt};
+use futures::{channel::mpsc, stream::SplitSink, Sink, SinkExt, Stream, StreamExt};
 use futures_util::ready;
 use pin_project::pin_project;
 use tokio::sync::broadcast;
@@ -23,88 +23,110 @@ const CAPACITY: usize = 100;
 pub struct Hub {
     // Shared data between clients
     inner: Arc<Mutex<Option<Inner>>>,
+    handles: Arc<Mutex<Vec<OwnedJoinHandle<()>>>>,
 
+    /// Stream where client can read frames from the device.
     #[pin]
     device_rx: BroadcastStream<Bytes>,
+    /// Sink where client can write frames to the device.
     #[pin]
     device_tx: mpsc::Sender<Bytes>,
-
-    // Join handle containing the wrapped transport
-    read_handle: Arc<OwnedJoinHandle<()>>,
-    send_handle: Arc<OwnedJoinHandle<()>>,
 }
 
 impl Hub {
     pub fn new(transport: Transport) -> Self {
         let (read_tx, read_rx) = broadcast::channel::<Bytes>(CAPACITY);
         let (send_tx, mut send_rx) = mpsc::channel(CAPACITY);
-        let (mut device_tx, mut device_rx) = transport.split();
-        let inner = Arc::new(Mutex::new(Some(Inner::new(read_tx))));
+        let (device_tx, mut device_rx) = transport.split();
+
+        let inner = Inner::new(read_tx, device_tx);
 
         let read_handle = {
-            let inner = inner.clone();
-            let read_tx = {
-                let inner = inner.lock().unwrap();
-                inner.as_ref().unwrap().device_rx.clone()
-            };
-
+            let read_tx_shared = inner.device_rx.clone();
             OwnedJoinHandle::new(tokio::spawn(async move {
                 while let Some(frame) = device_rx.next().await {
                     match frame {
                         Ok(frame) => {
-                            if let Err(e) = read_tx.send(frame) {
-                                // receiver is gone
-                                log::error!("read_tx receiver is gone: {}", e);
-                                break;
+                            let result = {
+                                let read_tx = read_tx_shared.write().unwrap();
+                                read_tx.send(frame)
+                            };
+                            match result {
+                                Err(e) => {
+                                    log::error!("send error {}", e);
+                                    break;
+                                }
+                                _ => {}
                             }
                         }
                         Err(e) => {
-                            // The upstream transport reported an error
                             log::error!("recv error {}", e);
                             break;
                         }
                     }
                 }
-                inner.lock().unwrap().take();
             }))
         };
 
         let send_handle = {
+            let transport_sink_shared = inner.transport_sink.clone();
+
             OwnedJoinHandle::new(tokio::spawn({
-                let inner = inner.clone();
                 async move {
+                    let mut transport_sink = transport_sink_shared.lock().await;
                     while let Some(frame) = send_rx.next().await {
-                        let res = device_tx.send(frame).await;
+                        let res = transport_sink.send(frame).await;
                         if let Err(e) = res {
-                            log::error!("device_tx: {}", e);
+                            log::error!("error sending to device: {e}");
                             break;
                         }
                     }
-                    inner.lock().unwrap().take();
                 }
             }))
         };
 
+        let handles = Arc::new(Mutex::new(vec![read_handle, send_handle]));
+
         Self {
-            inner,
+            inner: Arc::new(Mutex::new(Some(inner))),
+            handles,
             device_rx: BroadcastStream::new(read_rx),
             device_tx: send_tx,
+        }
+    }
 
-            send_handle: Arc::new(send_handle),
-            read_handle: Arc::new(read_handle),
+    pub async fn shutdown(&self) {
+        let handles: Vec<_> = { self.handles.lock().unwrap().drain(..).collect() };
+        for h in handles.iter() {
+            h.abort();
+        }
+        let inner = { self.inner.lock().unwrap().take() };
+        if let Some(inner) = inner {
+            let mut transport_sink = inner.transport_sink.lock().await;
+            let res = transport_sink.close().await;
+            if let Err(e) = res {
+                log::error!("error closing transport: {}", e);
+            }
+        }
+        for h in handles {
+            let res = h.await;
+            if let Err(e) = res {
+                if !e.is_cancelled() {
+                    log::error!("error joining handle: {}", e);
+                }
+            }
         }
     }
 
     /// Clones the transport if it is still available, returns None if it has been closed
     pub fn try_clone(&self) -> Option<Self> {
         let inner = self.inner.lock().unwrap();
-        let device_rx = BroadcastStream::new(inner.as_ref()?.device_rx.subscribe());
+        let device_rx = BroadcastStream::new(inner.as_ref()?.device_rx.read().unwrap().subscribe());
         Some(Self {
             inner: self.inner.clone(),
+            handles: self.handles.clone(),
             device_rx,
             device_tx: self.device_tx.clone(),
-            send_handle: self.send_handle.clone(),
-            read_handle: self.read_handle.clone(),
         })
     }
 }
@@ -162,11 +184,18 @@ impl Sink<Bytes> for Hub {
 
 struct Inner {
     // Broadcast sender used for creating receivers through .subscribe()
-    device_rx: broadcast::Sender<Bytes>,
+    device_rx: Arc<RwLock<broadcast::Sender<Bytes>>>,
+    transport_sink: Arc<tokio::sync::Mutex<SplitSink<Transport, Bytes>>>,
 }
 
 impl Inner {
-    pub fn new(device_rx: broadcast::Sender<Bytes>) -> Self {
-        Self { device_rx }
+    pub fn new(
+        device_rx: broadcast::Sender<Bytes>,
+        transport_sink: SplitSink<Transport, Bytes>,
+    ) -> Self {
+        Self {
+            device_rx: Arc::new(RwLock::new(device_rx)),
+            transport_sink: Arc::new(tokio::sync::Mutex::new(transport_sink)),
+        }
     }
 }

--- a/minidsp/src/transport/mod.rs
+++ b/minidsp/src/transport/mod.rs
@@ -22,7 +22,7 @@ pub mod hid;
 #[cfg(feature = "hid")]
 use hidapi::HidError;
 
-use crate::utils::StreamSink;
+use crate::{utils::StreamSink};
 
 pub mod frame_codec;
 pub mod multiplexer;
@@ -95,6 +95,38 @@ pub enum MiniDSPError {
 
     #[error("A device request timed out")]
     Timeout,
+
+    #[error("Device not ready")]
+    DeviceNotReady,
+}
+
+impl MiniDSPError {
+    pub fn is_retryable(&self) -> bool {
+        match self {
+            MiniDSPError::InternalError(err) => {
+                match err.root_cause().downcast_ref::<&MiniDSPError>() {
+                    Some(root_minidsp_err) => root_minidsp_err.is_retryable(),
+                    _ => false
+                }
+            }
+            MiniDSPError::Timeout => true,
+            MiniDSPError::DeviceNotReady => true,
+            _ => false,
+        }
+    }
+
+    pub fn should_reconnect(&self) -> bool {
+        match self {
+            MiniDSPError::InternalError(err) => {
+                match err.root_cause().downcast_ref::<&MiniDSPError>() {
+                    Some(root_minidsp_err) => root_minidsp_err.is_retryable(),
+                    _ => false
+                }
+            }
+            MiniDSPError::Timeout => true,
+            _ => false,
+        }
+    }
 }
 
 #[async_trait]

--- a/minidsp/src/transport/multiplexer.rs
+++ b/minidsp/src/transport/multiplexer.rs
@@ -4,10 +4,7 @@
 //! channel.
 
 use std::{
-    collections::VecDeque,
-    pin::Pin,
-    sync::{Arc, Mutex},
-    task::{Context, Poll},
+    collections::VecDeque,  pin::Pin, sync::{Arc, Mutex}, task::{Context, Poll}
 };
 
 use bytes::Bytes;
@@ -65,12 +62,11 @@ impl Multiplexer {
 
         // Spawn the receive task
         {
-            let transport = transport.clone();
             let receiver_tx = transport.event_tx.clone();
             let pending_commands = transport.pending_command.clone();
 
             tokio::spawn(async move {
-                let result = transport.recv_loop(recv_send, rx).await;
+                let result = Multiplexer::recv_loop(pending_commands.clone(), recv_send, rx).await;
                 if let Err(e) = result {
                     log::error!("recv loop exit: {:?}", e);
 
@@ -79,6 +75,8 @@ impl Multiplexer {
                     while let Some((_, tx)) = pending.pop_front() {
                         let _ = tx.send(Err(MiniDSPError::TransportClosed));
                     }
+                } else {
+                    log::warn!("recv loop exited without an error");
                 }
                 let mut tx = receiver_tx.lock().unwrap();
                 // Set `receiver_tx` to None to mark this as closed
@@ -119,7 +117,7 @@ impl Multiplexer {
     /// Receives responses from the transport, dispatches responses to the first pending command if it matches, else
     /// pushes it to the events broadcast channel.
     async fn recv_loop(
-        self: Arc<Self>,
+        pending_command: Arc<Mutex<VecDeque<PendingCommandTuple>>>,
         sender: broadcast::Sender<Responses>,
         mut stream: BoxStream,
     ) -> Result<(), MiniDSPError> {
@@ -133,7 +131,7 @@ impl Multiplexer {
             log::trace!("recv: {:02x?}", data);
 
             {
-                let mut pending_cmd = self.pending_command.lock().unwrap();
+                let mut pending_cmd = pending_command.lock().unwrap();
                 let matches = if let Some((cmd, _)) = pending_cmd.front() {
                     cmd.matches_response(&data)
                 } else {
@@ -192,6 +190,15 @@ impl std::ops::Deref for MultiplexerService {
 
     fn deref(&self) -> &Self::Target {
         &self.0
+    }
+}
+
+impl MultiplexerService {
+    pub async fn shutdown(&self) {
+        let mut write = self.write.lock().await;
+        if let Err(e) = write.close().await {
+            log::error!("error shutting down multiplexer service: {}", e);
+        }
     }
 }
 


### PR DESCRIPTION
I was experiencing an issue where the HTTP service would, after a few hours of working, get into a state where every request timed out. I believe this problem was caused by a failure to clean up a disconnected USB transport. As a workaround I implemented some changes that explicitly close and clean up a device and its transport upon certain errors. I've tested these changes in my local setup for a few days now and the problem appears to be fixed.