### PR TITLE
added volume, source, and preset endpoints

### DIFF
--- a/daemon/src/http/mod.rs
+++ b/daemon/src/http/mod.rs
@@ -5,6 +5,7 @@ use futures::{future::join_all, SinkExt, StreamExt};
 use hyper::header::{self, HeaderValue};
 use hyper::{body::HttpBody, Body, Request, Response, Server, StatusCode};
 use hyper_tungstenite::tungstenite::{self, Message};
+use minidsp::Source;
 use minidsp::{
     model::{Config, MasterStatus, StatusSummary},
     utils::{ErrInto, OwnedJoinHandle},
@@ -242,6 +243,82 @@ async fn post_master_status(mut req: Request<Body>) -> Result<Response<Body>, Er
     Ok(serialize_response(&req, status)?)
 }
 
+const VOLUME_INCREMENT: f32 = 0.5;
+enum VolumeDirection {
+    Up,
+    Down,
+    ToggleMute,
+}
+
+impl FromStr for VolumeDirection {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "up" => Ok(VolumeDirection::Up),
+            "down" => Ok(VolumeDirection::Down),
+            "toggle_mute" => Ok(VolumeDirection::ToggleMute),
+            _ => Err(Error::ParseError {
+                reason: "Incorrect value".to_string(),
+            }),
+        }
+    }
+}
+async fn update_volume(req: Request<Body>) -> Result<Response<Body>, Error> {
+    let device_index: usize = parse_param(&req, "deviceIndex")?;
+    let direction: VolumeDirection = parse_param(&req, "direction")?;
+
+    let app = super::APP.get().unwrap();
+    let app = app.read().await;
+    let device = get_device_instance(&app, device_index).await?;
+
+    let status = device.get_master_status().await?;
+    let current_gain = status.volume.unwrap().0;
+    let current_mute = status.mute.unwrap();
+    match direction {
+        VolumeDirection::Down => {
+            device
+                .set_master_volume(minidsp::Gain(current_gain - VOLUME_INCREMENT))
+                .await?;
+        }
+        VolumeDirection::Up => {
+            device
+                .set_master_volume(minidsp::Gain(current_gain + VOLUME_INCREMENT))
+                .await?;
+        }
+        VolumeDirection::ToggleMute => {
+            device.set_master_mute(!current_mute).await?;
+        }
+    };
+    let status = device.get_master_status().await?;
+    Ok(serialize_response(&req, status)?)
+}
+
+async fn update_source(req: Request<Body>) -> Result<Response<Body>, Error> {
+    let device_index: usize = parse_param(&req, "deviceIndex")?;
+    let source: Source = parse_param(&req, "source")?;
+
+    let app = super::APP.get().unwrap();
+    let app = app.read().await;
+    let device = get_device_instance(&app, device_index).await?;
+
+    device.set_source(source).await?;
+    let status = device.get_master_status().await?;
+    Ok(serialize_response(&req, status)?)
+}
+
+async fn update_preset(req: Request<Body>) -> Result<Response<Body>, Error> {
+    let device_index: usize = parse_param(&req, "deviceIndex")?;
+    let preset: u8 = parse_param(&req, "preset")?;
+
+    let app = super::APP.get().unwrap();
+    let app = app.read().await;
+    let device = get_device_instance(&app, device_index).await?;
+
+    device.set_config(preset).await?;
+    let status = device.get_master_status().await?;
+    Ok(serialize_response(&req, status)?)
+}
 /// Updates the device's configuration based on the defined elements. Anything set will be changed and anything else will be ignored.
 /// If a `master_status` object is passed, and the active configuration is changed, it will be applied before anything else. it is therefore
 /// safe to change config and apply other changes to the target config using a single call.
@@ -299,6 +376,9 @@ fn router(server: Option<HttpServer>) -> Router<Body, Error> {
         .get("/devices/get.schema", schema_fn::<Vec<Device>>)
         .get("/devices/:deviceIndex", get_master_status)
         .post("/devices/:deviceIndex", post_master_status)
+        .post("/devices/:deviceIndex/volume/:direction", update_volume)
+        .post("/devices/:deviceIndex/source/:source", update_source)
+        .post("/devices/:deviceIndex/preset/:preset", update_preset)
         .get(
             "/devices/:deviceIndex/get.schema",
             schema_fn::<StatusSummary>,

--- a/daemon/src/http/openapi/mod.rs
+++ b/daemon/src/http/openapi/mod.rs
@@ -260,6 +260,192 @@ pub fn schema() -> OpenApi {
         });
     }
 
+    // POST /devices/:deviceIndex/volume/:direction
+    {
+        let responses = gen.json_responses::<StatusSummary, FormattedError>(Some(StatusSummary {
+            master: MasterStatus {
+                preset: Some(0),
+                source: Some(Source::Toslink),
+                volume: Some(Gain(-5f32)),
+                mute: Some(false),
+                dirac: Some(false),
+            },
+            input_levels: [-51f32, -50f32].into(),
+            output_levels: [-51f32, -50f32, -127f32, -127f32].into(),
+        }));
+        let param = Parameter {
+            name: "deviceIndex".into(),
+            location: "path".into(),
+            description: None,
+            required: true,
+            deprecated: false,
+            allow_empty_value: false,
+            value: ParameterValue::Schema {
+                style: None,
+                explode: None,
+                allow_reserved: false,
+                schema: Default::default(),
+                example: None,
+                examples: None,
+            },
+            extensions: Default::default(),
+        }
+        .into();
+        let param_direction = Parameter {
+            name: "direction".into(),
+            location: "path".into(),
+            description: None,
+            required: true,
+            deprecated: false,
+            allow_empty_value: false,
+            value: ParameterValue::Schema {
+                style: None,
+                explode: None,
+                allow_reserved: false,
+                schema: Default::default(),
+                example: None,
+                examples: None,
+            },
+            extensions: Default::default(),
+        }
+        .into();
+        gen.add_operation(OperationInfo {
+            path: "/devices/{deviceIndex}/volume/{direction}".to_string(),
+            method: Method::POST,
+            operation: Operation {
+                summary: Some("Status summary".into()),
+                responses,
+                request_body: None,
+                parameters: vec![param, param_direction],
+                ..Default::default()
+            },
+        });
+    }
+
+    // POST /devices/:deviceIndex/source/:source
+    {
+        let responses = gen.json_responses::<StatusSummary, FormattedError>(Some(StatusSummary {
+            master: MasterStatus {
+                preset: Some(0),
+                source: Some(Source::Toslink),
+                volume: Some(Gain(-5f32)),
+                mute: Some(false),
+                dirac: Some(false),
+            },
+            input_levels: [-51f32, -50f32].into(),
+            output_levels: [-51f32, -50f32, -127f32, -127f32].into(),
+        }));
+        let param = Parameter {
+            name: "deviceIndex".into(),
+            location: "path".into(),
+            description: None,
+            required: true,
+            deprecated: false,
+            allow_empty_value: false,
+            value: ParameterValue::Schema {
+                style: None,
+                explode: None,
+                allow_reserved: false,
+                schema: Default::default(),
+                example: None,
+                examples: None,
+            },
+            extensions: Default::default(),
+        }
+        .into();
+        let param_source = Parameter {
+            name: "source".into(),
+            location: "path".into(),
+            description: None,
+            required: true,
+            deprecated: false,
+            allow_empty_value: false,
+            value: ParameterValue::Schema {
+                style: None,
+                explode: None,
+                allow_reserved: false,
+                schema: Default::default(),
+                example: None,
+                examples: None,
+            },
+            extensions: Default::default(),
+        }
+        .into();
+        gen.add_operation(OperationInfo {
+            path: "/devices/{deviceIndex}/source/{source}".to_string(),
+            method: Method::POST,
+            operation: Operation {
+                summary: Some("Status summary".into()),
+                responses,
+                request_body: None,
+                parameters: vec![param, param_source],
+                ..Default::default()
+            },
+        });
+    }
+
+    // POST /devices/:deviceIndex/preset/:preset
+    {
+        let responses = gen.json_responses::<StatusSummary, FormattedError>(Some(StatusSummary {
+            master: MasterStatus {
+                preset: Some(0),
+                source: Some(Source::Toslink),
+                volume: Some(Gain(-5f32)),
+                mute: Some(false),
+                dirac: Some(false),
+            },
+            input_levels: [-51f32, -50f32].into(),
+            output_levels: [-51f32, -50f32, -127f32, -127f32].into(),
+        }));
+        let param = Parameter {
+            name: "deviceIndex".into(),
+            location: "path".into(),
+            description: None,
+            required: true,
+            deprecated: false,
+            allow_empty_value: false,
+            value: ParameterValue::Schema {
+                style: None,
+                explode: None,
+                allow_reserved: false,
+                schema: Default::default(),
+                example: None,
+                examples: None,
+            },
+            extensions: Default::default(),
+        }
+        .into();
+        let param_preset = Parameter {
+            name: "preset".into(),
+            location: "path".into(),
+            description: None,
+            required: true,
+            deprecated: false,
+            allow_empty_value: false,
+            value: ParameterValue::Schema {
+                style: None,
+                explode: None,
+                allow_reserved: false,
+                schema: Default::default(),
+                example: None,
+                examples: None,
+            },
+            extensions: Default::default(),
+        }
+        .into();
+        gen.add_operation(OperationInfo {
+            path: "/devices/{deviceIndex}/preset/{preset}".to_string(),
+            method: Method::POST,
+            operation: Operation {
+                summary: Some("Status summary".into()),
+                responses,
+                request_body: None,
+                parameters: vec![param, param_preset],
+                ..Default::default()
+            },
+        });
+    }
+
     // POST /devices/:deviceIndex/config
     {
         let responses = gen.json_err_response::<FormattedError>();


### PR DESCRIPTION
https://github.com/mrene/minidsp-rs/discussions/225

This allows the following calls:

`curl -X POST 127.0.0.1/devices/0/volume/up`
`curl -X POST 127.0.0.1/devices/0/volume/down`
`curl -X POST 127.0.0.1/devices/0/volume/toggle_mute`

`curl -X POST 127.0.0.1/devices/0/source/spdif`

`curl -X POST 127.0.0.1/devices/0/preset/2`