### PR TITLE
Fix Flex HTx Input PEQ mapping and device detection

### DIFF
--- a/devtools/src/codegen/flexhtx/config.xml
+++ b/devtools/src/codegen/flexhtx/config.xml
@@ -1,86 +1,88 @@
-<setting version="1.1.17" defn="2.0">
-  <timestamp>3522065641</timestamp>
-  <lastsaved>1718375424701</lastsaved>
-  <dspversion>113</dspversion>
-  <label name="Input1" text="L-Front" immutable="false"/>
-  <label name="Input2" text="R-Front" immutable="false"/>
-  <label name="Input3" text="LFE" immutable="false"/>
-  <label name="Input4" text="Center" immutable="false"/>
-  <label name="Input5" text="L-Surround" immutable="false"/>
-  <label name="Input6" text="R-Surround" immutable="false"/>
-  <label name="Input7" text="L-Back" immutable="false"/>
-  <label name="Input8" text="R-Back" immutable="false"/>
-  <label name="Output1" text="Sat Left"/>
-  <label name="Output2" text="Sat Right"/>
-  <label name="Output3" text="Output 3"/>
-  <label name="Output4" text="Sat C"/>
-  <label name="Output5" text="Sat SL"/>
-  <label name="Output6" text="Sat SR"/>
-  <label name="Output7" text="SubFront"/>
-  <label name="Output8" text="SubBack"/>
+<?xml version="1.0"?>
+<setting version="1.2.3" defn="2.0">
+  <customname>No Boost</customname>
+  <timestamp>4242624449</timestamp>
+  <lastsaved>1776040547443</lastsaved>
+  <dspversion>115</dspversion>
+  <label name="Input1" text="FL Sub" immutable="false"/>
+  <label name="Input2" text="FR Sub" immutable="false"/>
+  <label name="Input3" text="RL Sub" immutable="false"/>
+  <label name="Input4" text="RR Sub" immutable="false"/>
+  <label name="Input5" text="N/A" immutable="false"/>
+  <label name="Input6" text="N/A" immutable="false"/>
+  <label name="Input7" text="N/A" immutable="false"/>
+  <label name="Input8" text="N/A" immutable="false"/>
+  <label name="Output1" text="FL Sub"/>
+  <label name="Output2" text="FR Sub"/>
+  <label name="Output3" text="RL Sub"/>
+  <label name="Output4" text="RR Sub"/>
+  <label name="Output5" text="Crowson L"/>
+  <label name="Output6" text="Crowson R"/>
+  <label name="Output7" text="N/A"/>
+  <label name="Output8" text="N/A"/>
   <item name="BM_DGain_1_status" addr="40">
-    <dec>2</dec>
-    <hex>00000002</hex>
+    <dec>1</dec>
+    <hex>00000001</hex>
   </item>
   <item name="BM_DGain_2_status" addr="41">
-    <dec>2</dec>
-    <hex>00000002</hex>
+    <dec>1</dec>
+    <hex>00000001</hex>
   </item>
   <item name="BM_DGain_3_status" addr="42">
-    <dec>2</dec>
-    <hex>00000002</hex>
+    <dec>1</dec>
+    <hex>00000001</hex>
   </item>
   <item name="BM_DGain_4_status" addr="43">
-    <dec>2</dec>
-    <hex>00000002</hex>
+    <dec>1</dec>
+    <hex>00000001</hex>
   </item>
   <item name="BM_DGain_5_status" addr="44">
-    <dec>2</dec>
-    <hex>00000002</hex>
+    <dec>1</dec>
+    <hex>00000001</hex>
   </item>
   <item name="BM_DGain_6_status" addr="45">
-    <dec>2</dec>
-    <hex>00000002</hex>
+    <dec>1</dec>
+    <hex>00000001</hex>
   </item>
   <item name="BM_DGain_7_status" addr="46">
-    <dec>2</dec>
-    <hex>00000002</hex>
+    <dec>1</dec>
+    <hex>00000001</hex>
   </item>
   <item name="BM_DGain_8_status" addr="47">
-    <dec>2</dec>
-    <hex>00000002</hex>
+    <dec>1</dec>
+    <hex>00000001</hex>
   </item>
   <item name="BM_DGain_1" addr="48">
-    <dec>-10</dec>
-    <hex>c1200000</hex>
+    <dec>0</dec>
+    <hex>00000000</hex>
   </item>
   <item name="BM_DGain_2" addr="49">
-    <dec>-10</dec>
-    <hex>c1200000</hex>
+    <dec>0</dec>
+    <hex>00000000</hex>
   </item>
   <item name="BM_DGain_3" addr="50">
     <dec>0</dec>
     <hex>00000000</hex>
   </item>
   <item name="BM_DGain_4" addr="51">
-    <dec>-10</dec>
-    <hex>c1200000</hex>
+    <dec>0</dec>
+    <hex>00000000</hex>
   </item>
   <item name="BM_DGain_5" addr="52">
-    <dec>-10</dec>
-    <hex>c1200000</hex>
+    <dec>0</dec>
+    <hex>00000000</hex>
   </item>
   <item name="BM_DGain_6" addr="53">
-    <dec>-10</dec>
-    <hex>c1200000</hex>
+    <dec>0</dec>
+    <hex>00000000</hex>
   </item>
   <item name="BM_DGain_7" addr="54">
-    <dec>-10</dec>
-    <hex>c1200000</hex>
+    <dec>0</dec>
+    <hex>00000000</hex>
   </item>
   <item name="BM_DGain_8" addr="55">
-    <dec>-10</dec>
-    <hex>c1200000</hex>
+    <dec>0</dec>
+    <hex>00000000</hex>
   </item>
   <item name="BM_Mixer_1_1_status" addr="56">
     <dec>2</dec>
@@ -155,8 +157,8 @@
     <hex>00000001</hex>
   </item>
   <item name="BM_Mixer_3_3_status" addr="74">
-    <dec>1</dec>
-    <hex>00000001</hex>
+    <dec>2</dec>
+    <hex>00000002</hex>
   </item>
   <item name="BM_Mixer_3_4_status" addr="75">
     <dec>1</dec>
@@ -227,8 +229,8 @@
     <hex>00000001</hex>
   </item>
   <item name="BM_Mixer_5_5_status" addr="92">
-    <dec>2</dec>
-    <hex>00000002</hex>
+    <dec>1</dec>
+    <hex>00000001</hex>
   </item>
   <item name="BM_Mixer_5_6_status" addr="93">
     <dec>1</dec>
@@ -263,8 +265,8 @@
     <hex>00000001</hex>
   </item>
   <item name="BM_Mixer_6_6_status" addr="101">
-    <dec>2</dec>
-    <hex>00000002</hex>
+    <dec>1</dec>
+    <hex>00000001</hex>
   </item>
   <item name="BM_Mixer_6_7_status" addr="102">
     <dec>1</dec>
@@ -291,8 +293,8 @@
     <hex>00000001</hex>
   </item>
   <item name="BM_Mixer_7_5_status" addr="108">
-    <dec>2</dec>
-    <hex>00000002</hex>
+    <dec>1</dec>
+    <hex>00000001</hex>
   </item>
   <item name="BM_Mixer_7_6_status" addr="109">
     <dec>1</dec>
@@ -327,8 +329,8 @@
     <hex>00000001</hex>
   </item>
   <item name="BM_Mixer_8_6_status" addr="117">
-    <dec>2</dec>
-    <hex>00000002</hex>
+    <dec>1</dec>
+    <hex>00000001</hex>
   </item>
   <item name="BM_Mixer_8_7_status" addr="118">
     <dec>1</dec>
@@ -347,8 +349,8 @@
     <hex>00000001</hex>
   </item>
   <item name="BM_Mixer_9_3_status" addr="122">
-    <dec>2</dec>
-    <hex>00000002</hex>
+    <dec>1</dec>
+    <hex>00000001</hex>
   </item>
   <item name="BM_Mixer_9_4_status" addr="123">
     <dec>1</dec>
@@ -1019,8 +1021,8 @@
     <hex>00000001</hex>
   </item>
   <item name="Out_Mixer_2_2_status" addr="610">
-    <dec>1</dec>
-    <hex>00000001</hex>
+    <dec>2</dec>
+    <hex>00000002</hex>
   </item>
   <item name="Out_Mixer_2_3_status" addr="611">
     <dec>1</dec>
@@ -1035,12 +1037,12 @@
     <hex>00000001</hex>
   </item>
   <item name="Out_Mixer_2_6_status" addr="614">
-    <dec>2</dec>
-    <hex>00000002</hex>
+    <dec>1</dec>
+    <hex>00000001</hex>
   </item>
   <item name="Out_Mixer_2_7_status" addr="615">
-    <dec>2</dec>
-    <hex>00000002</hex>
+    <dec>1</dec>
+    <hex>00000001</hex>
   </item>
   <item name="Out_Mixer_3_0_status" addr="616">
     <dec>1</dec>
@@ -1059,12 +1061,12 @@
     <hex>00000002</hex>
   </item>
   <item name="Out_Mixer_3_4_status" addr="620">
-    <dec>1</dec>
-    <hex>00000001</hex>
+    <dec>2</dec>
+    <hex>00000002</hex>
   </item>
   <item name="Out_Mixer_3_5_status" addr="621">
-    <dec>1</dec>
-    <hex>00000001</hex>
+    <dec>2</dec>
+    <hex>00000002</hex>
   </item>
   <item name="Out_Mixer_3_6_status" addr="622">
     <dec>1</dec>
@@ -1091,8 +1093,8 @@
     <hex>00000001</hex>
   </item>
   <item name="Out_Mixer_4_4_status" addr="628">
-    <dec>2</dec>
-    <hex>00000002</hex>
+    <dec>1</dec>
+    <hex>00000001</hex>
   </item>
   <item name="Out_Mixer_4_5_status" addr="629">
     <dec>1</dec>
@@ -1127,8 +1129,8 @@
     <hex>00000001</hex>
   </item>
   <item name="Out_Mixer_5_5_status" addr="637">
-    <dec>2</dec>
-    <hex>00000002</hex>
+    <dec>1</dec>
+    <hex>00000001</hex>
   </item>
   <item name="Out_Mixer_5_6_status" addr="638">
     <dec>1</dec>
@@ -1810,109 +1812,109 @@
     <dec>0</dec>
     <hex>00000000</hex>
   </item>
-  <item name="Meter_Comp_1" addr="808">
+  <item name="Meter_Comp_9" addr="808">
     <dec>0</dec>
     <hex>00000000</hex>
   </item>
-  <item name="Meter_Comp_2" addr="809">
+  <item name="Meter_Comp_10" addr="809">
     <dec>0</dec>
     <hex>00000000</hex>
   </item>
-  <item name="Meter_Comp_3" addr="810">
+  <item name="Meter_Comp_11" addr="810">
     <dec>0</dec>
     <hex>00000000</hex>
   </item>
-  <item name="Meter_Comp_4" addr="811">
+  <item name="Meter_Comp_12" addr="811">
     <dec>0</dec>
     <hex>00000000</hex>
   </item>
-  <item name="Meter_Comp_5" addr="812">
+  <item name="Meter_Comp_13" addr="812">
     <dec>0</dec>
     <hex>00000000</hex>
   </item>
-  <item name="Meter_Comp_6" addr="813">
+  <item name="Meter_Comp_14" addr="813">
     <dec>0</dec>
     <hex>00000000</hex>
   </item>
-  <item name="Meter_Comp_7" addr="814">
+  <item name="Meter_Comp_15" addr="814">
     <dec>0</dec>
     <hex>00000000</hex>
   </item>
-  <item name="Meter_Comp_8" addr="815">
+  <item name="Meter_Comp_16" addr="815">
     <dec>0</dec>
     <hex>00000000</hex>
   </item>
-  <item name="Meter_Out_1" addr="816">
+  <item name="Meter_Out_9" addr="816">
     <dec>0</dec>
     <hex>00000000</hex>
   </item>
-  <item name="Meter_Out_2" addr="817">
+  <item name="Meter_Out_10" addr="817">
     <dec>0</dec>
     <hex>00000000</hex>
   </item>
-  <item name="Meter_Out_3" addr="818">
+  <item name="Meter_Out_11" addr="818">
     <dec>0</dec>
     <hex>00000000</hex>
   </item>
-  <item name="Meter_Out_4" addr="819">
+  <item name="Meter_Out_12" addr="819">
     <dec>0</dec>
     <hex>00000000</hex>
   </item>
-  <item name="Meter_Out_5" addr="820">
+  <item name="Meter_Out_13" addr="820">
     <dec>0</dec>
     <hex>00000000</hex>
   </item>
-  <item name="Meter_Out_6" addr="821">
+  <item name="Meter_Out_14" addr="821">
     <dec>0</dec>
     <hex>00000000</hex>
   </item>
-  <item name="Meter_Out_7" addr="822">
+  <item name="Meter_Out_15" addr="822">
     <dec>0</dec>
     <hex>00000000</hex>
   </item>
-  <item name="Meter_Out_8" addr="823">
+  <item name="Meter_Out_16" addr="823">
     <dec>0</dec>
     <hex>00000000</hex>
   </item>
-  <item name="DGain_1_0_status" addr="824">
+  <item name="DGain_9_0_status" addr="824">
     <dec>2</dec>
     <hex>00000002</hex>
   </item>
-  <item name="COMP_1_0_status" addr="825">
-    <dec>3</dec>
-    <hex>00000003</hex>
+  <item name="COMP_9_0_status" addr="825">
+    <dec>2</dec>
+    <hex>00000002</hex>
   </item>
-  <item name="DGain_1_0" addr="826">
-    <dec>0.4</dec>
-    <hex>3ecccccd</hex>
-  </item>
-  <item name="COMP_1_0_threshold" addr="827">
-    <dec>-30</dec>
-    <hex>c1f00000</hex>
-  </item>
-  <item name="COMP_1_0_gain" addr="828">
+  <item name="DGain_9_0" addr="826">
     <dec>0</dec>
     <hex>00000000</hex>
   </item>
-  <item name="COMP_1_0_ratio" addr="829">
-    <dec>4</dec>
-    <hex>40800000</hex>
+  <item name="COMP_9_0_threshold" addr="827">
+    <dec>-5</dec>
+    <hex>c0a00000</hex>
   </item>
-  <item name="COMP_1_0_knee" addr="830">
+  <item name="COMP_9_0_gain" addr="828">
+    <dec>0</dec>
+    <hex>00000000</hex>
+  </item>
+  <item name="COMP_9_0_ratio" addr="829">
+    <dec>50</dec>
+    <hex>42480000</hex>
+  </item>
+  <item name="COMP_9_0_knee" addr="830">
     <dec>20</dec>
     <hex>41a00000</hex>
   </item>
-  <item name="COMP_1_0_atime" addr="831">
-    <dec>40</dec>
-    <hex>42200000</hex>
+  <item name="COMP_9_0_atime" addr="831">
+    <dec>15</dec>
+    <hex>41700000</hex>
   </item>
-  <item name="COMP_1_0_rtime" addr="832">
-    <dec>100</dec>
-    <hex>42c80000</hex>
+  <item name="COMP_9_0_rtime" addr="832">
+    <dec>150</dec>
+    <hex>43160000</hex>
   </item>
-  <item name="Delay_1_0" addr="833">
-    <dec>12</dec>
-    <hex>00000240</hex>
+  <item name="Delay_9_0" addr="833">
+    <dec>0</dec>
+    <hex>00000000</hex>
   </item>
   <item name="Meter_1_0" addr="834">
     <dec>0</dec>
@@ -1926,49 +1928,49 @@
     <dec>0</dec>
     <hex>00000000</hex>
   </item>
-  <item name="polarity_out_1_0" addr="837">
+  <item name="polarity_out_9_0" addr="837">
     <dec>0</dec>
     <hex>00000000</hex>
   </item>
-  <item name="DGain_2_0_status" addr="928">
+  <item name="DGain_10_0_status" addr="928">
     <dec>2</dec>
     <hex>00000002</hex>
   </item>
-  <item name="COMP_2_0_status" addr="929">
-    <dec>3</dec>
-    <hex>00000003</hex>
+  <item name="COMP_10_0_status" addr="929">
+    <dec>2</dec>
+    <hex>00000002</hex>
   </item>
-  <item name="DGain_2_0" addr="930">
-    <dec>1.2</dec>
-    <hex>3f99999a</hex>
-  </item>
-  <item name="COMP_2_0_threshold" addr="931">
-    <dec>-30</dec>
-    <hex>c1f00000</hex>
-  </item>
-  <item name="COMP_2_0_gain" addr="932">
+  <item name="DGain_10_0" addr="930">
     <dec>0</dec>
     <hex>00000000</hex>
   </item>
-  <item name="COMP_2_0_ratio" addr="933">
-    <dec>4</dec>
-    <hex>40800000</hex>
+  <item name="COMP_10_0_threshold" addr="931">
+    <dec>-5</dec>
+    <hex>c0a00000</hex>
   </item>
-  <item name="COMP_2_0_knee" addr="934">
+  <item name="COMP_10_0_gain" addr="932">
+    <dec>0</dec>
+    <hex>00000000</hex>
+  </item>
+  <item name="COMP_10_0_ratio" addr="933">
+    <dec>50</dec>
+    <hex>42480000</hex>
+  </item>
+  <item name="COMP_10_0_knee" addr="934">
     <dec>20</dec>
     <hex>41a00000</hex>
   </item>
-  <item name="COMP_2_0_atime" addr="935">
-    <dec>40</dec>
-    <hex>42200000</hex>
+  <item name="COMP_10_0_atime" addr="935">
+    <dec>15</dec>
+    <hex>41700000</hex>
   </item>
-  <item name="COMP_2_0_rtime" addr="936">
-    <dec>100</dec>
-    <hex>42c80000</hex>
+  <item name="COMP_10_0_rtime" addr="936">
+    <dec>150</dec>
+    <hex>43160000</hex>
   </item>
-  <item name="Delay_2_0" addr="937">
-    <dec>12.3</dec>
-    <hex>0000024e</hex>
+  <item name="Delay_10_0" addr="937">
+    <dec>0</dec>
+    <hex>00000000</hex>
   </item>
   <item name="Meter_2_0" addr="938">
     <dec>0</dec>
@@ -1982,47 +1984,47 @@
     <dec>0</dec>
     <hex>00000000</hex>
   </item>
-  <item name="polarity_out_2_0" addr="941">
+  <item name="polarity_out_10_0" addr="941">
     <dec>0</dec>
     <hex>00000000</hex>
   </item>
-  <item name="DGain_3_0_status" addr="1032">
+  <item name="DGain_11_0_status" addr="1032">
     <dec>2</dec>
     <hex>00000002</hex>
   </item>
-  <item name="COMP_3_0_status" addr="1033">
-    <dec>3</dec>
-    <hex>00000003</hex>
+  <item name="COMP_11_0_status" addr="1033">
+    <dec>2</dec>
+    <hex>00000002</hex>
   </item>
-  <item name="DGain_3_0" addr="1034">
+  <item name="DGain_11_0" addr="1034">
     <dec>0</dec>
     <hex>00000000</hex>
   </item>
-  <item name="COMP_3_0_threshold" addr="1035">
-    <dec>-30</dec>
-    <hex>c1f00000</hex>
+  <item name="COMP_11_0_threshold" addr="1035">
+    <dec>-5</dec>
+    <hex>c0a00000</hex>
   </item>
-  <item name="COMP_3_0_gain" addr="1036">
+  <item name="COMP_11_0_gain" addr="1036">
     <dec>0</dec>
     <hex>00000000</hex>
   </item>
-  <item name="COMP_3_0_ratio" addr="1037">
-    <dec>4</dec>
-    <hex>40800000</hex>
+  <item name="COMP_11_0_ratio" addr="1037">
+    <dec>50</dec>
+    <hex>42480000</hex>
   </item>
-  <item name="COMP_3_0_knee" addr="1038">
+  <item name="COMP_11_0_knee" addr="1038">
     <dec>20</dec>
     <hex>41a00000</hex>
   </item>
-  <item name="COMP_3_0_atime" addr="1039">
-    <dec>40</dec>
-    <hex>42200000</hex>
+  <item name="COMP_11_0_atime" addr="1039">
+    <dec>15</dec>
+    <hex>41700000</hex>
   </item>
-  <item name="COMP_3_0_rtime" addr="1040">
-    <dec>100</dec>
-    <hex>42c80000</hex>
+  <item name="COMP_11_0_rtime" addr="1040">
+    <dec>150</dec>
+    <hex>43160000</hex>
   </item>
-  <item name="Delay_3_0" addr="1041">
+  <item name="Delay_11_0" addr="1041">
     <dec>0</dec>
     <hex>00000000</hex>
   </item>
@@ -2038,49 +2040,49 @@
     <dec>0</dec>
     <hex>00000000</hex>
   </item>
-  <item name="polarity_out_3_0" addr="1045">
+  <item name="polarity_out_11_0" addr="1045">
     <dec>0</dec>
     <hex>00000000</hex>
   </item>
-  <item name="DGain_4_0_status" addr="1136">
+  <item name="DGain_12_0_status" addr="1136">
     <dec>2</dec>
     <hex>00000002</hex>
   </item>
-  <item name="COMP_4_0_status" addr="1137">
-    <dec>3</dec>
-    <hex>00000003</hex>
+  <item name="COMP_12_0_status" addr="1137">
+    <dec>2</dec>
+    <hex>00000002</hex>
   </item>
-  <item name="DGain_4_0" addr="1138">
-    <dec>-2.2</dec>
-    <hex>c00ccccd</hex>
-  </item>
-  <item name="COMP_4_0_threshold" addr="1139">
-    <dec>-30</dec>
-    <hex>c1f00000</hex>
-  </item>
-  <item name="COMP_4_0_gain" addr="1140">
+  <item name="DGain_12_0" addr="1138">
     <dec>0</dec>
     <hex>00000000</hex>
   </item>
-  <item name="COMP_4_0_ratio" addr="1141">
-    <dec>4</dec>
-    <hex>40800000</hex>
+  <item name="COMP_12_0_threshold" addr="1139">
+    <dec>-5</dec>
+    <hex>c0a00000</hex>
   </item>
-  <item name="COMP_4_0_knee" addr="1142">
+  <item name="COMP_12_0_gain" addr="1140">
+    <dec>0</dec>
+    <hex>00000000</hex>
+  </item>
+  <item name="COMP_12_0_ratio" addr="1141">
+    <dec>50</dec>
+    <hex>42480000</hex>
+  </item>
+  <item name="COMP_12_0_knee" addr="1142">
     <dec>20</dec>
     <hex>41a00000</hex>
   </item>
-  <item name="COMP_4_0_atime" addr="1143">
-    <dec>40</dec>
-    <hex>42200000</hex>
+  <item name="COMP_12_0_atime" addr="1143">
+    <dec>15</dec>
+    <hex>41700000</hex>
   </item>
-  <item name="COMP_4_0_rtime" addr="1144">
-    <dec>100</dec>
-    <hex>42c80000</hex>
+  <item name="COMP_12_0_rtime" addr="1144">
+    <dec>150</dec>
+    <hex>43160000</hex>
   </item>
-  <item name="Delay_4_0" addr="1145">
-    <dec>11.35</dec>
-    <hex>00000221</hex>
+  <item name="Delay_12_0" addr="1145">
+    <dec>0</dec>
+    <hex>00000000</hex>
   </item>
   <item name="Meter_4_0" addr="1146">
     <dec>0</dec>
@@ -2094,49 +2096,49 @@
     <dec>0</dec>
     <hex>00000000</hex>
   </item>
-  <item name="polarity_out_4_0" addr="1149">
+  <item name="polarity_out_12_0" addr="1149">
     <dec>0</dec>
     <hex>00000000</hex>
   </item>
-  <item name="DGain_5_0_status" addr="1240">
+  <item name="DGain_13_0_status" addr="1240">
     <dec>2</dec>
     <hex>00000002</hex>
   </item>
-  <item name="COMP_5_0_status" addr="1241">
-    <dec>3</dec>
-    <hex>00000003</hex>
+  <item name="COMP_13_0_status" addr="1241">
+    <dec>2</dec>
+    <hex>00000002</hex>
   </item>
-  <item name="DGain_5_0" addr="1242">
-    <dec>-0.3</dec>
-    <hex>be99999a</hex>
-  </item>
-  <item name="COMP_5_0_threshold" addr="1243">
-    <dec>-30</dec>
-    <hex>c1f00000</hex>
-  </item>
-  <item name="COMP_5_0_gain" addr="1244">
+  <item name="DGain_13_0" addr="1242">
     <dec>0</dec>
     <hex>00000000</hex>
   </item>
-  <item name="COMP_5_0_ratio" addr="1245">
-    <dec>4</dec>
-    <hex>40800000</hex>
+  <item name="COMP_13_0_threshold" addr="1243">
+    <dec>-5</dec>
+    <hex>c0a00000</hex>
   </item>
-  <item name="COMP_5_0_knee" addr="1246">
+  <item name="COMP_13_0_gain" addr="1244">
+    <dec>0</dec>
+    <hex>00000000</hex>
+  </item>
+  <item name="COMP_13_0_ratio" addr="1245">
+    <dec>50</dec>
+    <hex>42480000</hex>
+  </item>
+  <item name="COMP_13_0_knee" addr="1246">
     <dec>20</dec>
     <hex>41a00000</hex>
   </item>
-  <item name="COMP_5_0_atime" addr="1247">
-    <dec>40</dec>
-    <hex>42200000</hex>
+  <item name="COMP_13_0_atime" addr="1247">
+    <dec>15</dec>
+    <hex>41700000</hex>
   </item>
-  <item name="COMP_5_0_rtime" addr="1248">
-    <dec>100</dec>
-    <hex>42c80000</hex>
+  <item name="COMP_13_0_rtime" addr="1248">
+    <dec>150</dec>
+    <hex>43160000</hex>
   </item>
-  <item name="Delay_5_0" addr="1249">
-    <dec>9.6</dec>
-    <hex>000001cd</hex>
+  <item name="Delay_13_0" addr="1249">
+    <dec>0</dec>
+    <hex>00000000</hex>
   </item>
   <item name="Meter_5_0" addr="1250">
     <dec>0</dec>
@@ -2150,49 +2152,49 @@
     <dec>0</dec>
     <hex>00000000</hex>
   </item>
-  <item name="polarity_out_5_0" addr="1253">
+  <item name="polarity_out_13_0" addr="1253">
     <dec>0</dec>
     <hex>00000000</hex>
   </item>
-  <item name="DGain_6_0_status" addr="1344">
+  <item name="DGain_14_0_status" addr="1344">
     <dec>2</dec>
     <hex>00000002</hex>
   </item>
-  <item name="COMP_6_0_status" addr="1345">
-    <dec>3</dec>
-    <hex>00000003</hex>
+  <item name="COMP_14_0_status" addr="1345">
+    <dec>2</dec>
+    <hex>00000002</hex>
   </item>
-  <item name="DGain_6_0" addr="1346">
-    <dec>-0.6</dec>
-    <hex>bf19999a</hex>
-  </item>
-  <item name="COMP_6_0_threshold" addr="1347">
-    <dec>-30</dec>
-    <hex>c1f00000</hex>
-  </item>
-  <item name="COMP_6_0_gain" addr="1348">
+  <item name="DGain_14_0" addr="1346">
     <dec>0</dec>
     <hex>00000000</hex>
   </item>
-  <item name="COMP_6_0_ratio" addr="1349">
-    <dec>4</dec>
-    <hex>40800000</hex>
+  <item name="COMP_14_0_threshold" addr="1347">
+    <dec>-5</dec>
+    <hex>c0a00000</hex>
   </item>
-  <item name="COMP_6_0_knee" addr="1350">
+  <item name="COMP_14_0_gain" addr="1348">
+    <dec>0</dec>
+    <hex>00000000</hex>
+  </item>
+  <item name="COMP_14_0_ratio" addr="1349">
+    <dec>50</dec>
+    <hex>42480000</hex>
+  </item>
+  <item name="COMP_14_0_knee" addr="1350">
     <dec>20</dec>
     <hex>41a00000</hex>
   </item>
-  <item name="COMP_6_0_atime" addr="1351">
-    <dec>40</dec>
-    <hex>42200000</hex>
+  <item name="COMP_14_0_atime" addr="1351">
+    <dec>15</dec>
+    <hex>41700000</hex>
   </item>
-  <item name="COMP_6_0_rtime" addr="1352">
-    <dec>100</dec>
-    <hex>42c80000</hex>
+  <item name="COMP_14_0_rtime" addr="1352">
+    <dec>150</dec>
+    <hex>43160000</hex>
   </item>
-  <item name="Delay_6_0" addr="1353">
-    <dec>10.07</dec>
-    <hex>000001e3</hex>
+  <item name="Delay_14_0" addr="1353">
+    <dec>0</dec>
+    <hex>00000000</hex>
   </item>
   <item name="Meter_6_0" addr="1354">
     <dec>0</dec>
@@ -2206,49 +2208,49 @@
     <dec>0</dec>
     <hex>00000000</hex>
   </item>
-  <item name="polarity_out_6_0" addr="1357">
+  <item name="polarity_out_14_0" addr="1357">
     <dec>0</dec>
     <hex>00000000</hex>
   </item>
-  <item name="DGain_7_0_status" addr="1448">
+  <item name="DGain_15_0_status" addr="1448">
     <dec>2</dec>
     <hex>00000002</hex>
   </item>
-  <item name="COMP_7_0_status" addr="1449">
+  <item name="COMP_15_0_status" addr="1449">
     <dec>3</dec>
     <hex>00000003</hex>
   </item>
-  <item name="DGain_7_0" addr="1450">
-    <dec>0.7</dec>
-    <hex>3f333333</hex>
-  </item>
-  <item name="COMP_7_0_threshold" addr="1451">
-    <dec>-30</dec>
-    <hex>c1f00000</hex>
-  </item>
-  <item name="COMP_7_0_gain" addr="1452">
+  <item name="DGain_15_0" addr="1450">
     <dec>0</dec>
     <hex>00000000</hex>
   </item>
-  <item name="COMP_7_0_ratio" addr="1453">
+  <item name="COMP_15_0_threshold" addr="1451">
+    <dec>-30</dec>
+    <hex>c1f00000</hex>
+  </item>
+  <item name="COMP_15_0_gain" addr="1452">
+    <dec>0</dec>
+    <hex>00000000</hex>
+  </item>
+  <item name="COMP_15_0_ratio" addr="1453">
     <dec>4</dec>
     <hex>40800000</hex>
   </item>
-  <item name="COMP_7_0_knee" addr="1454">
+  <item name="COMP_15_0_knee" addr="1454">
     <dec>20</dec>
     <hex>41a00000</hex>
   </item>
-  <item name="COMP_7_0_atime" addr="1455">
+  <item name="COMP_15_0_atime" addr="1455">
     <dec>40</dec>
     <hex>42200000</hex>
   </item>
-  <item name="COMP_7_0_rtime" addr="1456">
+  <item name="COMP_15_0_rtime" addr="1456">
     <dec>100</dec>
     <hex>42c80000</hex>
   </item>
-  <item name="Delay_7_0" addr="1457">
-    <dec>1.34</dec>
-    <hex>00000040</hex>
+  <item name="Delay_15_0" addr="1457">
+    <dec>0</dec>
+    <hex>00000000</hex>
   </item>
   <item name="Meter_7_0" addr="1458">
     <dec>0</dec>
@@ -2262,49 +2264,49 @@
     <dec>0</dec>
     <hex>00000000</hex>
   </item>
-  <item name="polarity_out_7_0" addr="1461">
+  <item name="polarity_out_15_0" addr="1461">
     <dec>0</dec>
     <hex>00000000</hex>
   </item>
-  <item name="DGain_8_0_status" addr="1552">
+  <item name="DGain_16_0_status" addr="1552">
     <dec>2</dec>
     <hex>00000002</hex>
   </item>
-  <item name="COMP_8_0_status" addr="1553">
+  <item name="COMP_16_0_status" addr="1553">
     <dec>3</dec>
     <hex>00000003</hex>
   </item>
-  <item name="DGain_8_0" addr="1554">
-    <dec>4.9</dec>
-    <hex>409ccccd</hex>
-  </item>
-  <item name="COMP_8_0_threshold" addr="1555">
-    <dec>-30</dec>
-    <hex>c1f00000</hex>
-  </item>
-  <item name="COMP_8_0_gain" addr="1556">
+  <item name="DGain_16_0" addr="1554">
     <dec>0</dec>
     <hex>00000000</hex>
   </item>
-  <item name="COMP_8_0_ratio" addr="1557">
+  <item name="COMP_16_0_threshold" addr="1555">
+    <dec>-30</dec>
+    <hex>c1f00000</hex>
+  </item>
+  <item name="COMP_16_0_gain" addr="1556">
+    <dec>0</dec>
+    <hex>00000000</hex>
+  </item>
+  <item name="COMP_16_0_ratio" addr="1557">
     <dec>4</dec>
     <hex>40800000</hex>
   </item>
-  <item name="COMP_8_0_knee" addr="1558">
+  <item name="COMP_16_0_knee" addr="1558">
     <dec>20</dec>
     <hex>41a00000</hex>
   </item>
-  <item name="COMP_8_0_atime" addr="1559">
+  <item name="COMP_16_0_atime" addr="1559">
     <dec>40</dec>
     <hex>42200000</hex>
   </item>
-  <item name="COMP_8_0_rtime" addr="1560">
+  <item name="COMP_16_0_rtime" addr="1560">
     <dec>100</dec>
     <hex>42c80000</hex>
   </item>
-  <item name="Delay_8_0" addr="1561">
-    <dec>13.12</dec>
-    <hex>00000276</hex>
+  <item name="Delay_16_0" addr="1561">
+    <dec>0</dec>
+    <hex>00000000</hex>
   </item>
   <item name="Meter_8_0" addr="1562">
     <dec>0</dec>
@@ -2318,10 +2320,730 @@
     <dec>0</dec>
     <hex>00000000</hex>
   </item>
-  <item name="polarity_out_8_0" addr="1565">
+  <item name="polarity_out_16_0" addr="1565">
     <dec>0</dec>
     <hex>00000000</hex>
   </item>
+  <filter name="PEQ_1_1" addr="1656">
+    <freq>20</freq>
+    <q>0.707</q>
+    <boost>0</boost>
+    <type>PK</type>
+    <bypass>0</bypass>
+    <dec>1,0,0,0,0</dec>
+    <hex>3f800000,00000000,00000000,00000000,00000000</hex>
+  </filter>
+  <filter name="PEQ_1_2" addr="1661">
+    <freq>40</freq>
+    <q>0.707</q>
+    <boost>0</boost>
+    <type>PK</type>
+    <bypass>0</bypass>
+    <dec>1,0,0,0,0</dec>
+    <hex>3f800000,00000000,00000000,00000000,00000000</hex>
+  </filter>
+  <filter name="PEQ_1_3" addr="1666">
+    <freq>80</freq>
+    <q>0.707</q>
+    <boost>0</boost>
+    <type>PK</type>
+    <bypass>0</bypass>
+    <dec>1,0,0,0,0</dec>
+    <hex>3f800000,00000000,00000000,00000000,00000000</hex>
+  </filter>
+  <filter name="PEQ_1_4" addr="1671">
+    <freq>160</freq>
+    <q>0.707</q>
+    <boost>0</boost>
+    <type>PK</type>
+    <bypass>0</bypass>
+    <dec>1,0,0,0,0</dec>
+    <hex>3f800000,00000000,00000000,00000000,00000000</hex>
+  </filter>
+  <filter name="PEQ_1_5" addr="1676">
+    <freq>320</freq>
+    <q>0.707</q>
+    <boost>0</boost>
+    <type>PK</type>
+    <bypass>0</bypass>
+    <dec>1,0,0,0,0</dec>
+    <hex>3f800000,00000000,00000000,00000000,00000000</hex>
+  </filter>
+  <filter name="PEQ_1_6" addr="1681">
+    <freq>640</freq>
+    <q>0.707</q>
+    <boost>0</boost>
+    <type>PK</type>
+    <bypass>0</bypass>
+    <dec>1,0,0,0,0</dec>
+    <hex>3f800000,00000000,00000000,00000000,00000000</hex>
+  </filter>
+  <filter name="PEQ_1_7" addr="1686">
+    <freq>1280</freq>
+    <q>0.707</q>
+    <boost>0</boost>
+    <type>PK</type>
+    <bypass>0</bypass>
+    <dec>1,0,0,0,0</dec>
+    <hex>3f800000,00000000,00000000,00000000,00000000</hex>
+  </filter>
+  <filter name="PEQ_1_8" addr="1691">
+    <freq>2560</freq>
+    <q>0.707</q>
+    <boost>0</boost>
+    <type>PK</type>
+    <bypass>0</bypass>
+    <dec>1,0,0,0,0</dec>
+    <hex>3f800000,00000000,00000000,00000000,00000000</hex>
+  </filter>
+  <filter name="PEQ_1_9" addr="1696">
+    <freq>5120</freq>
+    <q>0.707</q>
+    <boost>0</boost>
+    <type>PK</type>
+    <bypass>0</bypass>
+    <dec>1,0,0,0,0</dec>
+    <hex>3f800000,00000000,00000000,00000000,00000000</hex>
+  </filter>
+  <filter name="PEQ_1_10" addr="1701">
+    <freq>10240</freq>
+    <q>0.707</q>
+    <boost>0</boost>
+    <type>PK</type>
+    <bypass>0</bypass>
+    <dec>1,0,0,0,0</dec>
+    <hex>3f800000,00000000,00000000,00000000,00000000</hex>
+  </filter>
+  <filter name="PEQ_2_1" addr="1706">
+    <freq>20</freq>
+    <q>0.707</q>
+    <boost>0</boost>
+    <type>PK</type>
+    <bypass>0</bypass>
+    <dec>1,0,0,0,0</dec>
+    <hex>3f800000,00000000,00000000,00000000,00000000</hex>
+  </filter>
+  <filter name="PEQ_2_2" addr="1711">
+    <freq>40</freq>
+    <q>0.707</q>
+    <boost>0</boost>
+    <type>PK</type>
+    <bypass>0</bypass>
+    <dec>1,0,0,0,0</dec>
+    <hex>3f800000,00000000,00000000,00000000,00000000</hex>
+  </filter>
+  <filter name="PEQ_2_3" addr="1716">
+    <freq>80</freq>
+    <q>0.707</q>
+    <boost>0</boost>
+    <type>PK</type>
+    <bypass>0</bypass>
+    <dec>1,0,0,0,0</dec>
+    <hex>3f800000,00000000,00000000,00000000,00000000</hex>
+  </filter>
+  <filter name="PEQ_2_4" addr="1721">
+    <freq>160</freq>
+    <q>0.707</q>
+    <boost>0</boost>
+    <type>PK</type>
+    <bypass>0</bypass>
+    <dec>1,0,0,0,0</dec>
+    <hex>3f800000,00000000,00000000,00000000,00000000</hex>
+  </filter>
+  <filter name="PEQ_2_5" addr="1726">
+    <freq>320</freq>
+    <q>0.707</q>
+    <boost>0</boost>
+    <type>PK</type>
+    <bypass>0</bypass>
+    <dec>1,0,0,0,0</dec>
+    <hex>3f800000,00000000,00000000,00000000,00000000</hex>
+  </filter>
+  <filter name="PEQ_2_6" addr="1731">
+    <freq>640</freq>
+    <q>0.707</q>
+    <boost>0</boost>
+    <type>PK</type>
+    <bypass>0</bypass>
+    <dec>1,0,0,0,0</dec>
+    <hex>3f800000,00000000,00000000,00000000,00000000</hex>
+  </filter>
+  <filter name="PEQ_2_7" addr="1736">
+    <freq>1280</freq>
+    <q>0.707</q>
+    <boost>0</boost>
+    <type>PK</type>
+    <bypass>0</bypass>
+    <dec>1,0,0,0,0</dec>
+    <hex>3f800000,00000000,00000000,00000000,00000000</hex>
+  </filter>
+  <filter name="PEQ_2_8" addr="1741">
+    <freq>2560</freq>
+    <q>0.707</q>
+    <boost>0</boost>
+    <type>PK</type>
+    <bypass>0</bypass>
+    <dec>1,0,0,0,0</dec>
+    <hex>3f800000,00000000,00000000,00000000,00000000</hex>
+  </filter>
+  <filter name="PEQ_2_9" addr="1746">
+    <freq>5120</freq>
+    <q>0.707</q>
+    <boost>0</boost>
+    <type>PK</type>
+    <bypass>0</bypass>
+    <dec>1,0,0,0,0</dec>
+    <hex>3f800000,00000000,00000000,00000000,00000000</hex>
+  </filter>
+  <filter name="PEQ_2_10" addr="1751">
+    <freq>10240</freq>
+    <q>0.707</q>
+    <boost>0</boost>
+    <type>PK</type>
+    <bypass>0</bypass>
+    <dec>1,0,0,0,0</dec>
+    <hex>3f800000,00000000,00000000,00000000,00000000</hex>
+  </filter>
+  <filter name="PEQ_3_1" addr="1756">
+    <freq>20</freq>
+    <q>0.707</q>
+    <boost>0</boost>
+    <type>PK</type>
+    <bypass>0</bypass>
+    <dec>1,0,0,0,0</dec>
+    <hex>3f800000,00000000,00000000,00000000,00000000</hex>
+  </filter>
+  <filter name="PEQ_3_2" addr="1761">
+    <freq>40</freq>
+    <q>0.707</q>
+    <boost>0</boost>
+    <type>PK</type>
+    <bypass>0</bypass>
+    <dec>1,0,0,0,0</dec>
+    <hex>3f800000,00000000,00000000,00000000,00000000</hex>
+  </filter>
+  <filter name="PEQ_3_3" addr="1766">
+    <freq>80</freq>
+    <q>0.707</q>
+    <boost>0</boost>
+    <type>PK</type>
+    <bypass>0</bypass>
+    <dec>1,0,0,0,0</dec>
+    <hex>3f800000,00000000,00000000,00000000,00000000</hex>
+  </filter>
+  <filter name="PEQ_3_4" addr="1771">
+    <freq>160</freq>
+    <q>0.707</q>
+    <boost>0</boost>
+    <type>PK</type>
+    <bypass>0</bypass>
+    <dec>1,0,0,0,0</dec>
+    <hex>3f800000,00000000,00000000,00000000,00000000</hex>
+  </filter>
+  <filter name="PEQ_3_5" addr="1776">
+    <freq>320</freq>
+    <q>0.707</q>
+    <boost>0</boost>
+    <type>PK</type>
+    <bypass>0</bypass>
+    <dec>1,0,0,0,0</dec>
+    <hex>3f800000,00000000,00000000,00000000,00000000</hex>
+  </filter>
+  <filter name="PEQ_3_6" addr="1781">
+    <freq>640</freq>
+    <q>0.707</q>
+    <boost>0</boost>
+    <type>PK</type>
+    <bypass>0</bypass>
+    <dec>1,0,0,0,0</dec>
+    <hex>3f800000,00000000,00000000,00000000,00000000</hex>
+  </filter>
+  <filter name="PEQ_3_7" addr="1786">
+    <freq>1280</freq>
+    <q>0.707</q>
+    <boost>0</boost>
+    <type>PK</type>
+    <bypass>0</bypass>
+    <dec>1,0,0,0,0</dec>
+    <hex>3f800000,00000000,00000000,00000000,00000000</hex>
+  </filter>
+  <filter name="PEQ_3_8" addr="1791">
+    <freq>2560</freq>
+    <q>0.707</q>
+    <boost>0</boost>
+    <type>PK</type>
+    <bypass>0</bypass>
+    <dec>1,0,0,0,0</dec>
+    <hex>3f800000,00000000,00000000,00000000,00000000</hex>
+  </filter>
+  <filter name="PEQ_3_9" addr="1796">
+    <freq>5120</freq>
+    <q>0.707</q>
+    <boost>0</boost>
+    <type>PK</type>
+    <bypass>0</bypass>
+    <dec>1,0,0,0,0</dec>
+    <hex>3f800000,00000000,00000000,00000000,00000000</hex>
+  </filter>
+  <filter name="PEQ_3_10" addr="1801">
+    <freq>10240</freq>
+    <q>0.707</q>
+    <boost>0</boost>
+    <type>PK</type>
+    <bypass>0</bypass>
+    <dec>1,0,0,0,0</dec>
+    <hex>3f800000,00000000,00000000,00000000,00000000</hex>
+  </filter>
+  <filter name="PEQ_4_1" addr="1806">
+    <freq>20</freq>
+    <q>0.707</q>
+    <boost>0</boost>
+    <type>PK</type>
+    <bypass>0</bypass>
+    <dec>1,0,0,0,0</dec>
+    <hex>3f800000,00000000,00000000,00000000,00000000</hex>
+  </filter>
+  <filter name="PEQ_4_2" addr="1811">
+    <freq>40</freq>
+    <q>0.707</q>
+    <boost>0</boost>
+    <type>PK</type>
+    <bypass>0</bypass>
+    <dec>1,0,0,0,0</dec>
+    <hex>3f800000,00000000,00000000,00000000,00000000</hex>
+  </filter>
+  <filter name="PEQ_4_3" addr="1816">
+    <freq>80</freq>
+    <q>0.707</q>
+    <boost>0</boost>
+    <type>PK</type>
+    <bypass>0</bypass>
+    <dec>1,0,0,0,0</dec>
+    <hex>3f800000,00000000,00000000,00000000,00000000</hex>
+  </filter>
+  <filter name="PEQ_4_4" addr="1821">
+    <freq>160</freq>
+    <q>0.707</q>
+    <boost>0</boost>
+    <type>PK</type>
+    <bypass>0</bypass>
+    <dec>1,0,0,0,0</dec>
+    <hex>3f800000,00000000,00000000,00000000,00000000</hex>
+  </filter>
+  <filter name="PEQ_4_5" addr="1826">
+    <freq>320</freq>
+    <q>0.707</q>
+    <boost>0</boost>
+    <type>PK</type>
+    <bypass>0</bypass>
+    <dec>1,0,0,0,0</dec>
+    <hex>3f800000,00000000,00000000,00000000,00000000</hex>
+  </filter>
+  <filter name="PEQ_4_6" addr="1831">
+    <freq>640</freq>
+    <q>0.707</q>
+    <boost>0</boost>
+    <type>PK</type>
+    <bypass>0</bypass>
+    <dec>1,0,0,0,0</dec>
+    <hex>3f800000,00000000,00000000,00000000,00000000</hex>
+  </filter>
+  <filter name="PEQ_4_7" addr="1836">
+    <freq>1280</freq>
+    <q>0.707</q>
+    <boost>0</boost>
+    <type>PK</type>
+    <bypass>0</bypass>
+    <dec>1,0,0,0,0</dec>
+    <hex>3f800000,00000000,00000000,00000000,00000000</hex>
+  </filter>
+  <filter name="PEQ_4_8" addr="1841">
+    <freq>2560</freq>
+    <q>0.707</q>
+    <boost>0</boost>
+    <type>PK</type>
+    <bypass>0</bypass>
+    <dec>1,0,0,0,0</dec>
+    <hex>3f800000,00000000,00000000,00000000,00000000</hex>
+  </filter>
+  <filter name="PEQ_4_9" addr="1846">
+    <freq>5120</freq>
+    <q>0.707</q>
+    <boost>0</boost>
+    <type>PK</type>
+    <bypass>0</bypass>
+    <dec>1,0,0,0,0</dec>
+    <hex>3f800000,00000000,00000000,00000000,00000000</hex>
+  </filter>
+  <filter name="PEQ_4_10" addr="1851">
+    <freq>10240</freq>
+    <q>0.707</q>
+    <boost>0</boost>
+    <type>PK</type>
+    <bypass>0</bypass>
+    <dec>1,0,0,0,0</dec>
+    <hex>3f800000,00000000,00000000,00000000,00000000</hex>
+  </filter>
+  <filter name="PEQ_5_1" addr="1856">
+    <freq>20</freq>
+    <q>0.707</q>
+    <boost>0</boost>
+    <type>PK</type>
+    <bypass>0</bypass>
+    <dec>1,0,0,0,0</dec>
+    <hex>3f800000,00000000,00000000,00000000,00000000</hex>
+  </filter>
+  <filter name="PEQ_5_2" addr="1861">
+    <freq>40</freq>
+    <q>0.707</q>
+    <boost>0</boost>
+    <type>PK</type>
+    <bypass>0</bypass>
+    <dec>1,0,0,0,0</dec>
+    <hex>3f800000,00000000,00000000,00000000,00000000</hex>
+  </filter>
+  <filter name="PEQ_5_3" addr="1866">
+    <freq>80</freq>
+    <q>0.707</q>
+    <boost>0</boost>
+    <type>PK</type>
+    <bypass>0</bypass>
+    <dec>1,0,0,0,0</dec>
+    <hex>3f800000,00000000,00000000,00000000,00000000</hex>
+  </filter>
+  <filter name="PEQ_5_4" addr="1871">
+    <freq>160</freq>
+    <q>0.707</q>
+    <boost>0</boost>
+    <type>PK</type>
+    <bypass>0</bypass>
+    <dec>1,0,0,0,0</dec>
+    <hex>3f800000,00000000,00000000,00000000,00000000</hex>
+  </filter>
+  <filter name="PEQ_5_5" addr="1876">
+    <freq>320</freq>
+    <q>0.707</q>
+    <boost>0</boost>
+    <type>PK</type>
+    <bypass>0</bypass>
+    <dec>1,0,0,0,0</dec>
+    <hex>3f800000,00000000,00000000,00000000,00000000</hex>
+  </filter>
+  <filter name="PEQ_5_6" addr="1881">
+    <freq>640</freq>
+    <q>0.707</q>
+    <boost>0</boost>
+    <type>PK</type>
+    <bypass>0</bypass>
+    <dec>1,0,0,0,0</dec>
+    <hex>3f800000,00000000,00000000,00000000,00000000</hex>
+  </filter>
+  <filter name="PEQ_5_7" addr="1886">
+    <freq>1280</freq>
+    <q>0.707</q>
+    <boost>0</boost>
+    <type>PK</type>
+    <bypass>0</bypass>
+    <dec>1,0,0,0,0</dec>
+    <hex>3f800000,00000000,00000000,00000000,00000000</hex>
+  </filter>
+  <filter name="PEQ_5_8" addr="1891">
+    <freq>2560</freq>
+    <q>0.707</q>
+    <boost>0</boost>
+    <type>PK</type>
+    <bypass>0</bypass>
+    <dec>1,0,0,0,0</dec>
+    <hex>3f800000,00000000,00000000,00000000,00000000</hex>
+  </filter>
+  <filter name="PEQ_5_9" addr="1896">
+    <freq>5120</freq>
+    <q>0.707</q>
+    <boost>0</boost>
+    <type>PK</type>
+    <bypass>0</bypass>
+    <dec>1,0,0,0,0</dec>
+    <hex>3f800000,00000000,00000000,00000000,00000000</hex>
+  </filter>
+  <filter name="PEQ_5_10" addr="1901">
+    <freq>10240</freq>
+    <q>0.707</q>
+    <boost>0</boost>
+    <type>PK</type>
+    <bypass>0</bypass>
+    <dec>1,0,0,0,0</dec>
+    <hex>3f800000,00000000,00000000,00000000,00000000</hex>
+  </filter>
+  <filter name="PEQ_6_1" addr="1906">
+    <freq>20</freq>
+    <q>0.707</q>
+    <boost>0</boost>
+    <type>PK</type>
+    <bypass>0</bypass>
+    <dec>1,0,0,0,0</dec>
+    <hex>3f800000,00000000,00000000,00000000,00000000</hex>
+  </filter>
+  <filter name="PEQ_6_2" addr="1911">
+    <freq>40</freq>
+    <q>0.707</q>
+    <boost>0</boost>
+    <type>PK</type>
+    <bypass>0</bypass>
+    <dec>1,0,0,0,0</dec>
+    <hex>3f800000,00000000,00000000,00000000,00000000</hex>
+  </filter>
+  <filter name="PEQ_6_3" addr="1916">
+    <freq>80</freq>
+    <q>0.707</q>
+    <boost>0</boost>
+    <type>PK</type>
+    <bypass>0</bypass>
+    <dec>1,0,0,0,0</dec>
+    <hex>3f800000,00000000,00000000,00000000,00000000</hex>
+  </filter>
+  <filter name="PEQ_6_4" addr="1921">
+    <freq>160</freq>
+    <q>0.707</q>
+    <boost>0</boost>
+    <type>PK</type>
+    <bypass>0</bypass>
+    <dec>1,0,0,0,0</dec>
+    <hex>3f800000,00000000,00000000,00000000,00000000</hex>
+  </filter>
+  <filter name="PEQ_6_5" addr="1926">
+    <freq>320</freq>
+    <q>0.707</q>
+    <boost>0</boost>
+    <type>PK</type>
+    <bypass>0</bypass>
+    <dec>1,0,0,0,0</dec>
+    <hex>3f800000,00000000,00000000,00000000,00000000</hex>
+  </filter>
+  <filter name="PEQ_6_6" addr="1931">
+    <freq>640</freq>
+    <q>0.707</q>
+    <boost>0</boost>
+    <type>PK</type>
+    <bypass>0</bypass>
+    <dec>1,0,0,0,0</dec>
+    <hex>3f800000,00000000,00000000,00000000,00000000</hex>
+  </filter>
+  <filter name="PEQ_6_7" addr="1936">
+    <freq>1280</freq>
+    <q>0.707</q>
+    <boost>0</boost>
+    <type>PK</type>
+    <bypass>0</bypass>
+    <dec>1,0,0,0,0</dec>
+    <hex>3f800000,00000000,00000000,00000000,00000000</hex>
+  </filter>
+  <filter name="PEQ_6_8" addr="1941">
+    <freq>2560</freq>
+    <q>0.707</q>
+    <boost>0</boost>
+    <type>PK</type>
+    <bypass>0</bypass>
+    <dec>1,0,0,0,0</dec>
+    <hex>3f800000,00000000,00000000,00000000,00000000</hex>
+  </filter>
+  <filter name="PEQ_6_9" addr="1946">
+    <freq>5120</freq>
+    <q>0.707</q>
+    <boost>0</boost>
+    <type>PK</type>
+    <bypass>0</bypass>
+    <dec>1,0,0,0,0</dec>
+    <hex>3f800000,00000000,00000000,00000000,00000000</hex>
+  </filter>
+  <filter name="PEQ_6_10" addr="1951">
+    <freq>10240</freq>
+    <q>0.707</q>
+    <boost>0</boost>
+    <type>PK</type>
+    <bypass>0</bypass>
+    <dec>1,0,0,0,0</dec>
+    <hex>3f800000,00000000,00000000,00000000,00000000</hex>
+  </filter>
+  <filter name="PEQ_7_1" addr="1956">
+    <freq>20</freq>
+    <q>0.707</q>
+    <boost>0</boost>
+    <type>PK</type>
+    <bypass>0</bypass>
+    <dec>1,0,0,0,0</dec>
+    <hex>3f800000,00000000,00000000,00000000,00000000</hex>
+  </filter>
+  <filter name="PEQ_7_2" addr="1961">
+    <freq>40</freq>
+    <q>0.707</q>
+    <boost>0</boost>
+    <type>PK</type>
+    <bypass>0</bypass>
+    <dec>1,0,0,0,0</dec>
+    <hex>3f800000,00000000,00000000,00000000,00000000</hex>
+  </filter>
+  <filter name="PEQ_7_3" addr="1966">
+    <freq>80</freq>
+    <q>0.707</q>
+    <boost>0</boost>
+    <type>PK</type>
+    <bypass>0</bypass>
+    <dec>1,0,0,0,0</dec>
+    <hex>3f800000,00000000,00000000,00000000,00000000</hex>
+  </filter>
+  <filter name="PEQ_7_4" addr="1971">
+    <freq>160</freq>
+    <q>0.707</q>
+    <boost>0</boost>
+    <type>PK</type>
+    <bypass>0</bypass>
+    <dec>1,0,0,0,0</dec>
+    <hex>3f800000,00000000,00000000,00000000,00000000</hex>
+  </filter>
+  <filter name="PEQ_7_5" addr="1976">
+    <freq>320</freq>
+    <q>0.707</q>
+    <boost>0</boost>
+    <type>PK</type>
+    <bypass>0</bypass>
+    <dec>1,0,0,0,0</dec>
+    <hex>3f800000,00000000,00000000,00000000,00000000</hex>
+  </filter>
+  <filter name="PEQ_7_6" addr="1981">
+    <freq>640</freq>
+    <q>0.707</q>
+    <boost>0</boost>
+    <type>PK</type>
+    <bypass>0</bypass>
+    <dec>1,0,0,0,0</dec>
+    <hex>3f800000,00000000,00000000,00000000,00000000</hex>
+  </filter>
+  <filter name="PEQ_7_7" addr="1986">
+    <freq>1280</freq>
+    <q>0.707</q>
+    <boost>0</boost>
+    <type>PK</type>
+    <bypass>0</bypass>
+    <dec>1,0,0,0,0</dec>
+    <hex>3f800000,00000000,00000000,00000000,00000000</hex>
+  </filter>
+  <filter name="PEQ_7_8" addr="1991">
+    <freq>2560</freq>
+    <q>0.707</q>
+    <boost>0</boost>
+    <type>PK</type>
+    <bypass>0</bypass>
+    <dec>1,0,0,0,0</dec>
+    <hex>3f800000,00000000,00000000,00000000,00000000</hex>
+  </filter>
+  <filter name="PEQ_7_9" addr="1996">
+    <freq>5120</freq>
+    <q>0.707</q>
+    <boost>0</boost>
+    <type>PK</type>
+    <bypass>0</bypass>
+    <dec>1,0,0,0,0</dec>
+    <hex>3f800000,00000000,00000000,00000000,00000000</hex>
+  </filter>
+  <filter name="PEQ_7_10" addr="2001">
+    <freq>10240</freq>
+    <q>0.707</q>
+    <boost>0</boost>
+    <type>PK</type>
+    <bypass>0</bypass>
+    <dec>1,0,0,0,0</dec>
+    <hex>3f800000,00000000,00000000,00000000,00000000</hex>
+  </filter>
+  <filter name="PEQ_8_1" addr="2006">
+    <freq>20</freq>
+    <q>0.707</q>
+    <boost>0</boost>
+    <type>PK</type>
+    <bypass>0</bypass>
+    <dec>1,0,0,0,0</dec>
+    <hex>3f800000,00000000,00000000,00000000,00000000</hex>
+  </filter>
+  <filter name="PEQ_8_2" addr="2011">
+    <freq>40</freq>
+    <q>0.707</q>
+    <boost>0</boost>
+    <type>PK</type>
+    <bypass>0</bypass>
+    <dec>1,0,0,0,0</dec>
+    <hex>3f800000,00000000,00000000,00000000,00000000</hex>
+  </filter>
+  <filter name="PEQ_8_3" addr="2016">
+    <freq>80</freq>
+    <q>0.707</q>
+    <boost>0</boost>
+    <type>PK</type>
+    <bypass>0</bypass>
+    <dec>1,0,0,0,0</dec>
+    <hex>3f800000,00000000,00000000,00000000,00000000</hex>
+  </filter>
+  <filter name="PEQ_8_4" addr="2021">
+    <freq>160</freq>
+    <q>0.707</q>
+    <boost>0</boost>
+    <type>PK</type>
+    <bypass>0</bypass>
+    <dec>1,0,0,0,0</dec>
+    <hex>3f800000,00000000,00000000,00000000,00000000</hex>
+  </filter>
+  <filter name="PEQ_8_5" addr="2026">
+    <freq>320</freq>
+    <q>0.707</q>
+    <boost>0</boost>
+    <type>PK</type>
+    <bypass>0</bypass>
+    <dec>1,0,0,0,0</dec>
+    <hex>3f800000,00000000,00000000,00000000,00000000</hex>
+  </filter>
+  <filter name="PEQ_8_6" addr="2031">
+    <freq>640</freq>
+    <q>0.707</q>
+    <boost>0</boost>
+    <type>PK</type>
+    <bypass>0</bypass>
+    <dec>1,0,0,0,0</dec>
+    <hex>3f800000,00000000,00000000,00000000,00000000</hex>
+  </filter>
+  <filter name="PEQ_8_7" addr="2036">
+    <freq>1280</freq>
+    <q>0.707</q>
+    <boost>0</boost>
+    <type>PK</type>
+    <bypass>0</bypass>
+    <dec>1,0,0,0,0</dec>
+    <hex>3f800000,00000000,00000000,00000000,00000000</hex>
+  </filter>
+  <filter name="PEQ_8_8" addr="2041">
+    <freq>2560</freq>
+    <q>0.707</q>
+    <boost>0</boost>
+    <type>PK</type>
+    <bypass>0</bypass>
+    <dec>1,0,0,0,0</dec>
+    <hex>3f800000,00000000,00000000,00000000,00000000</hex>
+  </filter>
+  <filter name="PEQ_8_9" addr="2046">
+    <freq>5120</freq>
+    <q>0.707</q>
+    <boost>0</boost>
+    <type>PK</type>
+    <bypass>0</bypass>
+    <dec>1,0,0,0,0</dec>
+    <hex>3f800000,00000000,00000000,00000000,00000000</hex>
+  </filter>
+  <filter name="PEQ_8_10" addr="2051">
+    <freq>10240</freq>
+    <q>0.707</q>
+    <boost>0</boost>
+    <type>PK</type>
+    <bypass>0</bypass>
+    <dec>1,0,0,0,0</dec>
+    <hex>3f800000,00000000,00000000,00000000,00000000</hex>
+  </filter>
   <filter name="BM_BPF_ALL_1" addr="0">
     <freq>100</freq>
     <q>0</q>
@@ -2345,7 +3067,7 @@
     <q>0</q>
     <boost>0</boost>
     <type>LRLPF_4</type>
-    <bypass>0</bypass>
+    <bypass>1</bypass>
     <dec>0.000042443368140115214,0.00008488673628023043,0.000042443368140115214,1.9814885091390815,-0.9816582826116418,0.000042443368140115214,0.00008488673628023043,0.000042443368140115214,1.9814885091390815,-0.9816582826116418,1,0,0,0,0,1,0,0,0,0</dec>
     <hex>38320538,38b20538,38320538,3ffda16a,bf7b4df5,38320538,38b20538,38320538,3ffda16a,bf7b4df5,3f800000,00000000,00000000,00000000,00000000,3f800000,00000000,00000000,00000000,00000000</hex>
   </filter>
@@ -2354,7 +3076,7 @@
     <q>0</q>
     <boost>0</boost>
     <type>LRHPF_4</type>
-    <bypass>0</bypass>
+    <bypass>1</bypass>
     <dec>0.9907866979376808,-1.9815733958753616,0.9907866979376808,1.9814885091390815,-0.9816582826116418,0.9907866979376808,-1.9815733958753616,0.9907866979376808,1.9814885091390815,-0.9816582826116418,1,0,0,0,0,1,0,0,0,0</dec>
     <hex>3f7da432,bffda432,3f7da432,3ffda16a,bf7b4df5,3f7da432,bffda432,3f7da432,3ffda16a,bf7b4df5,3f800000,00000000,00000000,00000000,00000000,3f800000,00000000,00000000,00000000,00000000</hex>
   </filter>
@@ -2363,7 +3085,7 @@
     <q>0</q>
     <boost>0</boost>
     <type>LRLPF_4</type>
-    <bypass>0</bypass>
+    <bypass>1</bypass>
     <dec>0.000042443368140115214,0.00008488673628023043,0.000042443368140115214,1.9814885091390815,-0.9816582826116418,0.000042443368140115214,0.00008488673628023043,0.000042443368140115214,1.9814885091390815,-0.9816582826116418,1,0,0,0,0,1,0,0,0,0</dec>
     <hex>38320538,38b20538,38320538,3ffda16a,bf7b4df5,38320538,38b20538,38320538,3ffda16a,bf7b4df5,3f800000,00000000,00000000,00000000,00000000,3f800000,00000000,00000000,00000000,00000000</hex>
   </filter>
@@ -2372,18 +3094,18 @@
     <q>0</q>
     <boost>0</boost>
     <type>LRHPF_4</type>
-    <bypass>0</bypass>
+    <bypass>1</bypass>
     <dec>0.9907866979376808,-1.9815733958753616,0.9907866979376808,1.9814885091390815,-0.9816582826116418,0.9907866979376808,-1.9815733958753616,0.9907866979376808,1.9814885091390815,-0.9816582826116418,1,0,0,0,0,1,0,0,0,0</dec>
     <hex>3f7da432,bffda432,3f7da432,3ffda16a,bf7b4df5,3f7da432,bffda432,3f7da432,3ffda16a,bf7b4df5,3f800000,00000000,00000000,00000000,00000000,3f800000,00000000,00000000,00000000,00000000</hex>
   </filter>
   <filter name="BM_BPF_3_1" addr="352">
-    <freq>149</freq>
+    <freq>100</freq>
     <q>0</q>
     <boost>0</boost>
-    <type>BWLPF_4</type>
-    <bypass>0</bypass>
-    <dec>0.00009341582949742886,0.00018683165899485772,0.00009341582949742886,1.9642276507663052,-0.9646013140842948,0.00009439451514001328,0.00018878903028002656,0.00009439451514001328,1.984806190944287,-0.985183769004847,1,0,0,0,0,1,0,0,0,0</dec>
-    <hex>38c3e83e,3943e83e,38c3e83e,3ffb6bd0,bf76f01d,38c5f5ab,3945f5ab,38c5f5ab,3ffe0e21,bf7c3501,3f800000,00000000,00000000,80000000,80000000,3f800000,00000000,00000000,80000000,80000000</hex>
+    <type>LRLPF_4</type>
+    <bypass>1</bypass>
+    <dec>0.000042443368140115214,0.00008488673628023043,0.000042443368140115214,1.9814885091390815,-0.9816582826116418,0.000042443368140115214,0.00008488673628023043,0.000042443368140115214,1.9814885091390815,-0.9816582826116418,1,0,0,0,0,1,0,0,0,0</dec>
+    <hex>38320538,38b20538,38320538,3ffda16a,bf7b4df5,38320538,38b20538,38320538,3ffda16a,bf7b4df5,3f800000,00000000,00000000,00000000,00000000,3f800000,00000000,00000000,00000000,00000000</hex>
   </filter>
   <filter name="BM_BPF_3_5" addr="372">
     <freq>100</freq>
@@ -2399,25 +3121,25 @@
     <q>0</q>
     <boost>0</boost>
     <type>LRLPF_4</type>
-    <bypass>0</bypass>
+    <bypass>1</bypass>
     <dec>0.000042443368140115214,0.00008488673628023043,0.000042443368140115214,1.9814885091390815,-0.9816582826116418,0.000042443368140115214,0.00008488673628023043,0.000042443368140115214,1.9814885091390815,-0.9816582826116418,1,0,0,0,0,1,0,0,0,0</dec>
-    <hex>38320538,38b20538,38320538,3ffda16a,bf7b4df5,38320538,38b20538,38320538,3ffda16a,bf7b4df5,3f800000,00000000,00000000,80000000,80000000,3f800000,00000000,00000000,80000000,80000000</hex>
+    <hex>38320538,38b20538,38320538,3ffda16a,bf7b4df5,38320538,38b20538,38320538,3ffda16a,bf7b4df5,3f800000,00000000,00000000,00000000,00000000,3f800000,00000000,00000000,00000000,00000000</hex>
   </filter>
   <filter name="BM_BPF_4_5" addr="412">
     <freq>100</freq>
     <q>0</q>
     <boost>0</boost>
     <type>LRHPF_4</type>
-    <bypass>0</bypass>
+    <bypass>1</bypass>
     <dec>0.9907866979376808,-1.9815733958753616,0.9907866979376808,1.9814885091390815,-0.9816582826116418,0.9907866979376808,-1.9815733958753616,0.9907866979376808,1.9814885091390815,-0.9816582826116418,1,0,0,0,0,1,0,0,0,0</dec>
-    <hex>3f7da432,bffda432,3f7da432,3ffda16a,bf7b4df5,3f7da432,bffda432,3f7da432,3ffda16a,bf7b4df5,3f800000,00000000,00000000,80000000,80000000,3f800000,00000000,00000000,80000000,80000000</hex>
+    <hex>3f7da432,bffda432,3f7da432,3ffda16a,bf7b4df5,3f7da432,bffda432,3f7da432,3ffda16a,bf7b4df5,3f800000,00000000,00000000,00000000,00000000,3f800000,00000000,00000000,00000000,00000000</hex>
   </filter>
   <filter name="BM_BPF_5_1" addr="432">
     <freq>100</freq>
     <q>0</q>
     <boost>0</boost>
     <type>LRLPF_4</type>
-    <bypass>0</bypass>
+    <bypass>1</bypass>
     <dec>0.000042443368140115214,0.00008488673628023043,0.000042443368140115214,1.9814885091390815,-0.9816582826116418,0.000042443368140115214,0.00008488673628023043,0.000042443368140115214,1.9814885091390815,-0.9816582826116418,1,0,0,0,0,1,0,0,0,0</dec>
     <hex>38320538,38b20538,38320538,3ffda16a,bf7b4df5,38320538,38b20538,38320538,3ffda16a,bf7b4df5,3f800000,00000000,00000000,00000000,00000000,3f800000,00000000,00000000,00000000,00000000</hex>
   </filter>
@@ -2426,7 +3148,7 @@
     <q>0</q>
     <boost>0</boost>
     <type>LRHPF_4</type>
-    <bypass>0</bypass>
+    <bypass>1</bypass>
     <dec>0.9907866979376808,-1.9815733958753616,0.9907866979376808,1.9814885091390815,-0.9816582826116418,0.9907866979376808,-1.9815733958753616,0.9907866979376808,1.9814885091390815,-0.9816582826116418,1,0,0,0,0,1,0,0,0,0</dec>
     <hex>3f7da432,bffda432,3f7da432,3ffda16a,bf7b4df5,3f7da432,bffda432,3f7da432,3ffda16a,bf7b4df5,3f800000,00000000,00000000,00000000,00000000,3f800000,00000000,00000000,00000000,00000000</hex>
   </filter>
@@ -2435,7 +3157,7 @@
     <q>0</q>
     <boost>0</boost>
     <type>LRLPF_4</type>
-    <bypass>0</bypass>
+    <bypass>1</bypass>
     <dec>0.000042443368140115214,0.00008488673628023043,0.000042443368140115214,1.9814885091390815,-0.9816582826116418,0.000042443368140115214,0.00008488673628023043,0.000042443368140115214,1.9814885091390815,-0.9816582826116418,1,0,0,0,0,1,0,0,0,0</dec>
     <hex>38320538,38b20538,38320538,3ffda16a,bf7b4df5,38320538,38b20538,38320538,3ffda16a,bf7b4df5,3f800000,00000000,00000000,00000000,00000000,3f800000,00000000,00000000,00000000,00000000</hex>
   </filter>
@@ -2444,7 +3166,7 @@
     <q>0</q>
     <boost>0</boost>
     <type>LRHPF_4</type>
-    <bypass>0</bypass>
+    <bypass>1</bypass>
     <dec>0.9907866979376808,-1.9815733958753616,0.9907866979376808,1.9814885091390815,-0.9816582826116418,0.9907866979376808,-1.9815733958753616,0.9907866979376808,1.9814885091390815,-0.9816582826116418,1,0,0,0,0,1,0,0,0,0</dec>
     <hex>3f7da432,bffda432,3f7da432,3ffda16a,bf7b4df5,3f7da432,bffda432,3f7da432,3ffda16a,bf7b4df5,3f800000,00000000,00000000,00000000,00000000,3f800000,00000000,00000000,00000000,00000000</hex>
   </filter>
@@ -2453,7 +3175,7 @@
     <q>0</q>
     <boost>0</boost>
     <type>LRLPF_4</type>
-    <bypass>0</bypass>
+    <bypass>1</bypass>
     <dec>0.000042443368140115214,0.00008488673628023043,0.000042443368140115214,1.9814885091390815,-0.9816582826116418,0.000042443368140115214,0.00008488673628023043,0.000042443368140115214,1.9814885091390815,-0.9816582826116418,1,0,0,0,0,1,0,0,0,0</dec>
     <hex>38320538,38b20538,38320538,3ffda16a,bf7b4df5,38320538,38b20538,38320538,3ffda16a,bf7b4df5,3f800000,00000000,00000000,00000000,00000000,3f800000,00000000,00000000,00000000,00000000</hex>
   </filter>
@@ -2462,7 +3184,7 @@
     <q>0</q>
     <boost>0</boost>
     <type>LRHPF_4</type>
-    <bypass>0</bypass>
+    <bypass>1</bypass>
     <dec>0.9907866979376808,-1.9815733958753616,0.9907866979376808,1.9814885091390815,-0.9816582826116418,0.9907866979376808,-1.9815733958753616,0.9907866979376808,1.9814885091390815,-0.9816582826116418,1,0,0,0,0,1,0,0,0,0</dec>
     <hex>3f7da432,bffda432,3f7da432,3ffda16a,bf7b4df5,3f7da432,bffda432,3f7da432,3ffda16a,bf7b4df5,3f800000,00000000,00000000,00000000,00000000,3f800000,00000000,00000000,00000000,00000000</hex>
   </filter>
@@ -2471,7 +3193,7 @@
     <q>0</q>
     <boost>0</boost>
     <type>LRLPF_4</type>
-    <bypass>0</bypass>
+    <bypass>1</bypass>
     <dec>0.000042443368140115214,0.00008488673628023043,0.000042443368140115214,1.9814885091390815,-0.9816582826116418,0.000042443368140115214,0.00008488673628023043,0.000042443368140115214,1.9814885091390815,-0.9816582826116418,1,0,0,0,0,1,0,0,0,0</dec>
     <hex>38320538,38b20538,38320538,3ffda16a,bf7b4df5,38320538,38b20538,38320538,3ffda16a,bf7b4df5,3f800000,00000000,00000000,00000000,00000000,3f800000,00000000,00000000,00000000,00000000</hex>
   </filter>
@@ -2480,119 +3202,11 @@
     <q>0</q>
     <boost>0</boost>
     <type>LRHPF_4</type>
-    <bypass>0</bypass>
+    <bypass>1</bypass>
     <dec>0.9907866979376808,-1.9815733958753616,0.9907866979376808,1.9814885091390815,-0.9816582826116418,0.9907866979376808,-1.9815733958753616,0.9907866979376808,1.9814885091390815,-0.9816582826116418,1,0,0,0,0,1,0,0,0,0</dec>
     <hex>3f7da432,bffda432,3f7da432,3ffda16a,bf7b4df5,3f7da432,bffda432,3f7da432,3ffda16a,bf7b4df5,3f800000,00000000,00000000,00000000,00000000,3f800000,00000000,00000000,00000000,00000000</hex>
   </filter>
-  <filter name="PEQ_1_1" addr="838">
-    <freq>20</freq>
-    <q>0.7</q>
-    <boost>0</boost>
-    <type>PK</type>
-    <bypass>0</bypass>
-    <dec>1,0,0,0,0</dec>
-    <hex>3f800000,00000000,00000000,00000000,00000000</hex>
-  </filter>
-  <filter name="PEQ_1_2" addr="843">
-    <freq>40</freq>
-    <q>0.707</q>
-    <boost>0</boost>
-    <type>PK</type>
-    <bypass>0</bypass>
-    <dec>1,0,0,0,0</dec>
-    <hex>3f800000,00000000,00000000,00000000,00000000</hex>
-  </filter>
-  <filter name="PEQ_1_3" addr="848">
-    <freq>80</freq>
-    <q>0.707</q>
-    <boost>0</boost>
-    <type>PK</type>
-    <bypass>0</bypass>
-    <dec>1,0,0,0,0</dec>
-    <hex>3f800000,00000000,00000000,00000000,00000000</hex>
-  </filter>
-  <filter name="PEQ_1_4" addr="853">
-    <freq>158</freq>
-    <q>0.7</q>
-    <boost>-8.5</boost>
-    <type>PK</type>
-    <bypass>1</bypass>
-    <dec>0.9853143226242235,-1.9525251108204074,0.967628460308693,1.9525251108204074,-0.9529427829329166</dec>
-    <hex>3f7c3d8f,bff9ec58,3f77b680,3ff9ec58,bf73f40f</hex>
-  </filter>
-  <filter name="PEQ_1_5" addr="858">
-    <freq>320</freq>
-    <q>0.707</q>
-    <boost>0</boost>
-    <type>PK</type>
-    <bypass>0</bypass>
-    <dec>1,0,0,0,0</dec>
-    <hex>3f800000,00000000,00000000,00000000,00000000</hex>
-  </filter>
-  <filter name="PEQ_1_6" addr="863">
-    <freq>690</freq>
-    <q>0.7</q>
-    <boost>0.1</boost>
-    <type>PK</type>
-    <bypass>1</bypass>
-    <dec>1.000697095199667,-1.8719363946224592,0.8789008229714673,1.8719363946224592,-0.8795979181711342</dec>
-    <hex>3f8016d8,bfef9b9d,3f60ffa5,3fef9b9d,bf612d54</hex>
-  </filter>
-  <filter name="PEQ_1_7" addr="868">
-    <freq>1280</freq>
-    <q>0.707</q>
-    <boost>0</boost>
-    <type>PK</type>
-    <bypass>0</bypass>
-    <dec>1,0,0,0,0</dec>
-    <hex>3f800000,00000000,00000000,00000000,00000000</hex>
-  </filter>
-  <filter name="PEQ_1_8" addr="873">
-    <freq>2560</freq>
-    <q>0.707</q>
-    <boost>0</boost>
-    <type>PK</type>
-    <bypass>0</bypass>
-    <dec>1,0,0,0,0</dec>
-    <hex>3f800000,00000000,00000000,00000000,00000000</hex>
-  </filter>
-  <filter name="PEQ_1_9" addr="878">
-    <freq>5120</freq>
-    <q>0.707</q>
-    <boost>0</boost>
-    <type>PK</type>
-    <bypass>0</bypass>
-    <dec>1,0,0,0,0</dec>
-    <hex>3f800000,00000000,00000000,00000000,00000000</hex>
-  </filter>
-  <filter name="PEQ_1_10" addr="883">
-    <freq>10240</freq>
-    <q>0.707</q>
-    <boost>0</boost>
-    <type>PK</type>
-    <bypass>0</bypass>
-    <dec>1,0,0,0,0</dec>
-    <hex>3f800000,00000000,00000000,00000000,00000000</hex>
-  </filter>
-  <filter name="BPF_1_1" addr="888">
-    <freq>100</freq>
-    <q>0</q>
-    <boost>0</boost>
-    <type>BWLPF_4</type>
-    <bypass>1</bypass>
-    <dec>0.000042324375459811486,0.00008464875091962297,0.000042324375459811486,1.975933280159253,-0.9761025776610925,0.0000426227085455773,0.0000852454170911546,0.0000426227085455773,1.9898610999163815,-0.9900315907505638,1,0,0,0,0,1,0,0,0,0</dec>
-    <hex>38318574,38b18574,38318574,3ffceb62,bf79e1dc,3832c5c9,38b2c5c9,3832c5c9,3ffeb3c5,bf7d72b6,3f800000,00000000,00000000,00000000,00000000,3f800000,00000000,00000000,00000000,00000000</hex>
-  </filter>
-  <filter name="BPF_1_5" addr="908">
-    <freq>100</freq>
-    <q>0</q>
-    <boost>0</boost>
-    <type>BWHPF_4</type>
-    <bypass>1</bypass>
-    <dec>0.9880089644550863,-1.9760179289101727,0.9880089644550863,1.975933280159253,-0.9761025776610925,0.9949731726667363,-1.9899463453334727,0.9949731726667363,1.9898610999163815,-0.9900315907505638,1,0,0,0,0,1,0,0,0,0</dec>
-    <hex>3f7cee28,bffcee28,3f7cee28,3ffceb62,bf79e1dc,3f7eb690,bffeb690,3f7eb690,3ffeb3c5,bf7d72b6,3f800000,00000000,00000000,00000000,00000000,3f800000,00000000,00000000,00000000,00000000</hex>
-  </filter>
-  <filter name="PEQ_2_1" addr="942">
+  <filter name="PEQ_9_1" addr="838">
     <freq>20</freq>
     <q>0.707</q>
     <boost>0</boost>
@@ -2601,7 +3215,7 @@
     <dec>1,0,0,0,0</dec>
     <hex>3f800000,00000000,00000000,00000000,00000000</hex>
   </filter>
-  <filter name="PEQ_2_2" addr="947">
+  <filter name="PEQ_9_2" addr="843">
     <freq>40</freq>
     <q>0.707</q>
     <boost>0</boost>
@@ -2610,7 +3224,7 @@
     <dec>1,0,0,0,0</dec>
     <hex>3f800000,00000000,00000000,00000000,00000000</hex>
   </filter>
-  <filter name="PEQ_2_3" addr="952">
+  <filter name="PEQ_9_3" addr="848">
     <freq>80</freq>
     <q>0.707</q>
     <boost>0</boost>
@@ -2619,7 +3233,7 @@
     <dec>1,0,0,0,0</dec>
     <hex>3f800000,00000000,00000000,00000000,00000000</hex>
   </filter>
-  <filter name="PEQ_2_4" addr="957">
+  <filter name="PEQ_9_4" addr="853">
     <freq>160</freq>
     <q>0.707</q>
     <boost>0</boost>
@@ -2628,7 +3242,7 @@
     <dec>1,0,0,0,0</dec>
     <hex>3f800000,00000000,00000000,00000000,00000000</hex>
   </filter>
-  <filter name="PEQ_2_5" addr="962">
+  <filter name="PEQ_9_5" addr="858">
     <freq>320</freq>
     <q>0.707</q>
     <boost>0</boost>
@@ -2637,7 +3251,7 @@
     <dec>1,0,0,0,0</dec>
     <hex>3f800000,00000000,00000000,00000000,00000000</hex>
   </filter>
-  <filter name="PEQ_2_6" addr="967">
+  <filter name="PEQ_9_6" addr="863">
     <freq>640</freq>
     <q>0.707</q>
     <boost>0</boost>
@@ -2646,7 +3260,7 @@
     <dec>1,0,0,0,0</dec>
     <hex>3f800000,00000000,00000000,00000000,00000000</hex>
   </filter>
-  <filter name="PEQ_2_7" addr="972">
+  <filter name="PEQ_9_7" addr="868">
     <freq>1280</freq>
     <q>0.707</q>
     <boost>0</boost>
@@ -2655,7 +3269,7 @@
     <dec>1,0,0,0,0</dec>
     <hex>3f800000,00000000,00000000,00000000,00000000</hex>
   </filter>
-  <filter name="PEQ_2_8" addr="977">
+  <filter name="PEQ_9_8" addr="873">
     <freq>2560</freq>
     <q>0.707</q>
     <boost>0</boost>
@@ -2664,7 +3278,7 @@
     <dec>1,0,0,0,0</dec>
     <hex>3f800000,00000000,00000000,00000000,00000000</hex>
   </filter>
-  <filter name="PEQ_2_9" addr="982">
+  <filter name="PEQ_9_9" addr="878">
     <freq>5120</freq>
     <q>0.707</q>
     <boost>0</boost>
@@ -2673,7 +3287,7 @@
     <dec>1,0,0,0,0</dec>
     <hex>3f800000,00000000,00000000,00000000,00000000</hex>
   </filter>
-  <filter name="PEQ_2_10" addr="987">
+  <filter name="PEQ_9_10" addr="883">
     <freq>10240</freq>
     <q>0.707</q>
     <boost>0</boost>
@@ -2682,7 +3296,7 @@
     <dec>1,0,0,0,0</dec>
     <hex>3f800000,00000000,00000000,00000000,00000000</hex>
   </filter>
-  <filter name="BPF_2_1" addr="992">
+  <filter name="BPF_9_1" addr="888">
     <freq>100</freq>
     <q>0</q>
     <boost>0</boost>
@@ -2691,16 +3305,16 @@
     <dec>0.000042324375459811486,0.00008464875091962297,0.000042324375459811486,1.975933280159253,-0.9761025776610925,0.0000426227085455773,0.0000852454170911546,0.0000426227085455773,1.9898610999163815,-0.9900315907505638,1,0,0,0,0,1,0,0,0,0</dec>
     <hex>38318574,38b18574,38318574,3ffceb62,bf79e1dc,3832c5c9,38b2c5c9,3832c5c9,3ffeb3c5,bf7d72b6,3f800000,00000000,00000000,00000000,00000000,3f800000,00000000,00000000,00000000,00000000</hex>
   </filter>
-  <filter name="BPF_2_5" addr="1012">
-    <freq>100</freq>
+  <filter name="BPF_9_5" addr="908">
+    <freq>12</freq>
     <q>0</q>
     <boost>0</boost>
-    <type>BWHPF_4</type>
-    <bypass>1</bypass>
-    <dec>0.9880089644550863,-1.9760179289101727,0.9880089644550863,1.975933280159253,-0.9761025776610925,0.9949731726667363,-1.9899463453334727,0.9949731726667363,1.9898610999163815,-0.9900315907505638,1,0,0,0,0,1,0,0,0,0</dec>
-    <hex>3f7cee28,bffcee28,3f7cee28,3ffceb62,bf79e1dc,3f7eb690,bffeb690,3f7eb690,3ffeb3c5,bf7d72b6,3f800000,00000000,00000000,00000000,00000000,3f800000,00000000,00000000,00000000,00000000</hex>
+    <type>LRHPF_8</type>
+    <bypass>0</bypass>
+    <dec>0.9985502610695056,-1.9971005221390112,0.9985502610695056,1.9970992902264981,-0.9971017540515243,0.9985502610695056,-1.9971005221390112,0.9985502610695056,1.9970992902264981,-0.9971017540515243,0.9993986271631015,-1.998797254326203,0.9993986271631015,1.9987960213670597,-0.998798487285346,0.9993986271631015,-1.998797254326203,0.9993986271631015,1.9987960213670597,-0.998798487285346</dec>
+    <hex>3f7fa0fd,bfffa0fd,3f7fa0fd,3fffa0f3,bf7f4210,3f7fa0fd,bfffa0fd,3f7fa0fd,3fffa0f3,bf7f4210,3f7fd897,bfffd897,3f7fd897,3fffd88c,bf7fb142,3f7fd897,bfffd897,3f7fd897,3fffd88c,bf7fb142</hex>
   </filter>
-  <filter name="PEQ_3_1" addr="1046">
+  <filter name="PEQ_10_1" addr="942">
     <freq>20</freq>
     <q>0.707</q>
     <boost>0</boost>
@@ -2709,7 +3323,7 @@
     <dec>1,0,0,0,0</dec>
     <hex>3f800000,00000000,00000000,00000000,00000000</hex>
   </filter>
-  <filter name="PEQ_3_2" addr="1051">
+  <filter name="PEQ_10_2" addr="947">
     <freq>40</freq>
     <q>0.707</q>
     <boost>0</boost>
@@ -2718,7 +3332,7 @@
     <dec>1,0,0,0,0</dec>
     <hex>3f800000,00000000,00000000,00000000,00000000</hex>
   </filter>
-  <filter name="PEQ_3_3" addr="1056">
+  <filter name="PEQ_10_3" addr="952">
     <freq>80</freq>
     <q>0.707</q>
     <boost>0</boost>
@@ -2727,7 +3341,7 @@
     <dec>1,0,0,0,0</dec>
     <hex>3f800000,00000000,00000000,00000000,00000000</hex>
   </filter>
-  <filter name="PEQ_3_4" addr="1061">
+  <filter name="PEQ_10_4" addr="957">
     <freq>160</freq>
     <q>0.707</q>
     <boost>0</boost>
@@ -2736,7 +3350,7 @@
     <dec>1,0,0,0,0</dec>
     <hex>3f800000,00000000,00000000,00000000,00000000</hex>
   </filter>
-  <filter name="PEQ_3_5" addr="1066">
+  <filter name="PEQ_10_5" addr="962">
     <freq>320</freq>
     <q>0.707</q>
     <boost>0</boost>
@@ -2745,7 +3359,7 @@
     <dec>1,0,0,0,0</dec>
     <hex>3f800000,00000000,00000000,00000000,00000000</hex>
   </filter>
-  <filter name="PEQ_3_6" addr="1071">
+  <filter name="PEQ_10_6" addr="967">
     <freq>640</freq>
     <q>0.707</q>
     <boost>0</boost>
@@ -2754,7 +3368,7 @@
     <dec>1,0,0,0,0</dec>
     <hex>3f800000,00000000,00000000,00000000,00000000</hex>
   </filter>
-  <filter name="PEQ_3_7" addr="1076">
+  <filter name="PEQ_10_7" addr="972">
     <freq>1280</freq>
     <q>0.707</q>
     <boost>0</boost>
@@ -2763,7 +3377,7 @@
     <dec>1,0,0,0,0</dec>
     <hex>3f800000,00000000,00000000,00000000,00000000</hex>
   </filter>
-  <filter name="PEQ_3_8" addr="1081">
+  <filter name="PEQ_10_8" addr="977">
     <freq>2560</freq>
     <q>0.707</q>
     <boost>0</boost>
@@ -2772,7 +3386,7 @@
     <dec>1,0,0,0,0</dec>
     <hex>3f800000,00000000,00000000,00000000,00000000</hex>
   </filter>
-  <filter name="PEQ_3_9" addr="1086">
+  <filter name="PEQ_10_9" addr="982">
     <freq>5120</freq>
     <q>0.707</q>
     <boost>0</boost>
@@ -2781,7 +3395,7 @@
     <dec>1,0,0,0,0</dec>
     <hex>3f800000,00000000,00000000,00000000,00000000</hex>
   </filter>
-  <filter name="PEQ_3_10" addr="1091">
+  <filter name="PEQ_10_10" addr="987">
     <freq>10240</freq>
     <q>0.707</q>
     <boost>0</boost>
@@ -2790,7 +3404,7 @@
     <dec>1,0,0,0,0</dec>
     <hex>3f800000,00000000,00000000,00000000,00000000</hex>
   </filter>
-  <filter name="BPF_3_1" addr="1096">
+  <filter name="BPF_10_1" addr="992">
     <freq>100</freq>
     <q>0</q>
     <boost>0</boost>
@@ -2799,16 +3413,16 @@
     <dec>0.000042324375459811486,0.00008464875091962297,0.000042324375459811486,1.975933280159253,-0.9761025776610925,0.0000426227085455773,0.0000852454170911546,0.0000426227085455773,1.9898610999163815,-0.9900315907505638,1,0,0,0,0,1,0,0,0,0</dec>
     <hex>38318574,38b18574,38318574,3ffceb62,bf79e1dc,3832c5c9,38b2c5c9,3832c5c9,3ffeb3c5,bf7d72b6,3f800000,00000000,00000000,00000000,00000000,3f800000,00000000,00000000,00000000,00000000</hex>
   </filter>
-  <filter name="BPF_3_5" addr="1116">
-    <freq>100</freq>
+  <filter name="BPF_10_5" addr="1012">
+    <freq>12</freq>
     <q>0</q>
     <boost>0</boost>
-    <type>BWHPF_4</type>
-    <bypass>1</bypass>
-    <dec>0.9880089644550863,-1.9760179289101727,0.9880089644550863,1.975933280159253,-0.9761025776610925,0.9949731726667363,-1.9899463453334727,0.9949731726667363,1.9898610999163815,-0.9900315907505638,1,0,0,0,0,1,0,0,0,0</dec>
-    <hex>3f7cee28,bffcee28,3f7cee28,3ffceb62,bf79e1dc,3f7eb690,bffeb690,3f7eb690,3ffeb3c5,bf7d72b6,3f800000,00000000,00000000,00000000,00000000,3f800000,00000000,00000000,00000000,00000000</hex>
+    <type>LRHPF_8</type>
+    <bypass>0</bypass>
+    <dec>0.9985502610695056,-1.9971005221390112,0.9985502610695056,1.9970992902264981,-0.9971017540515243,0.9985502610695056,-1.9971005221390112,0.9985502610695056,1.9970992902264981,-0.9971017540515243,0.9993986271631015,-1.998797254326203,0.9993986271631015,1.9987960213670597,-0.998798487285346,0.9993986271631015,-1.998797254326203,0.9993986271631015,1.9987960213670597,-0.998798487285346</dec>
+    <hex>3f7fa0fd,bfffa0fd,3f7fa0fd,3fffa0f3,bf7f4210,3f7fa0fd,bfffa0fd,3f7fa0fd,3fffa0f3,bf7f4210,3f7fd897,bfffd897,3f7fd897,3fffd88c,bf7fb142,3f7fd897,bfffd897,3f7fd897,3fffd88c,bf7fb142</hex>
   </filter>
-  <filter name="PEQ_4_1" addr="1150">
+  <filter name="PEQ_11_1" addr="1046">
     <freq>20</freq>
     <q>0.707</q>
     <boost>0</boost>
@@ -2817,7 +3431,7 @@
     <dec>1,0,0,0,0</dec>
     <hex>3f800000,00000000,00000000,00000000,00000000</hex>
   </filter>
-  <filter name="PEQ_4_2" addr="1155">
+  <filter name="PEQ_11_2" addr="1051">
     <freq>40</freq>
     <q>0.707</q>
     <boost>0</boost>
@@ -2826,7 +3440,7 @@
     <dec>1,0,0,0,0</dec>
     <hex>3f800000,00000000,00000000,00000000,00000000</hex>
   </filter>
-  <filter name="PEQ_4_3" addr="1160">
+  <filter name="PEQ_11_3" addr="1056">
     <freq>80</freq>
     <q>0.707</q>
     <boost>0</boost>
@@ -2835,7 +3449,7 @@
     <dec>1,0,0,0,0</dec>
     <hex>3f800000,00000000,00000000,00000000,00000000</hex>
   </filter>
-  <filter name="PEQ_4_4" addr="1165">
+  <filter name="PEQ_11_4" addr="1061">
     <freq>160</freq>
     <q>0.707</q>
     <boost>0</boost>
@@ -2844,7 +3458,7 @@
     <dec>1,0,0,0,0</dec>
     <hex>3f800000,00000000,00000000,00000000,00000000</hex>
   </filter>
-  <filter name="PEQ_4_5" addr="1170">
+  <filter name="PEQ_11_5" addr="1066">
     <freq>320</freq>
     <q>0.707</q>
     <boost>0</boost>
@@ -2853,7 +3467,7 @@
     <dec>1,0,0,0,0</dec>
     <hex>3f800000,00000000,00000000,00000000,00000000</hex>
   </filter>
-  <filter name="PEQ_4_6" addr="1175">
+  <filter name="PEQ_11_6" addr="1071">
     <freq>640</freq>
     <q>0.707</q>
     <boost>0</boost>
@@ -2862,7 +3476,7 @@
     <dec>1,0,0,0,0</dec>
     <hex>3f800000,00000000,00000000,00000000,00000000</hex>
   </filter>
-  <filter name="PEQ_4_7" addr="1180">
+  <filter name="PEQ_11_7" addr="1076">
     <freq>1280</freq>
     <q>0.707</q>
     <boost>0</boost>
@@ -2871,7 +3485,7 @@
     <dec>1,0,0,0,0</dec>
     <hex>3f800000,00000000,00000000,00000000,00000000</hex>
   </filter>
-  <filter name="PEQ_4_8" addr="1185">
+  <filter name="PEQ_11_8" addr="1081">
     <freq>2560</freq>
     <q>0.707</q>
     <boost>0</boost>
@@ -2880,7 +3494,7 @@
     <dec>1,0,0,0,0</dec>
     <hex>3f800000,00000000,00000000,00000000,00000000</hex>
   </filter>
-  <filter name="PEQ_4_9" addr="1190">
+  <filter name="PEQ_11_9" addr="1086">
     <freq>5120</freq>
     <q>0.707</q>
     <boost>0</boost>
@@ -2889,7 +3503,7 @@
     <dec>1,0,0,0,0</dec>
     <hex>3f800000,00000000,00000000,00000000,00000000</hex>
   </filter>
-  <filter name="PEQ_4_10" addr="1195">
+  <filter name="PEQ_11_10" addr="1091">
     <freq>10240</freq>
     <q>0.707</q>
     <boost>0</boost>
@@ -2898,7 +3512,7 @@
     <dec>1,0,0,0,0</dec>
     <hex>3f800000,00000000,00000000,00000000,00000000</hex>
   </filter>
-  <filter name="BPF_4_1" addr="1200">
+  <filter name="BPF_11_1" addr="1096">
     <freq>100</freq>
     <q>0</q>
     <boost>0</boost>
@@ -2907,16 +3521,16 @@
     <dec>0.000042324375459811486,0.00008464875091962297,0.000042324375459811486,1.975933280159253,-0.9761025776610925,0.0000426227085455773,0.0000852454170911546,0.0000426227085455773,1.9898610999163815,-0.9900315907505638,1,0,0,0,0,1,0,0,0,0</dec>
     <hex>38318574,38b18574,38318574,3ffceb62,bf79e1dc,3832c5c9,38b2c5c9,3832c5c9,3ffeb3c5,bf7d72b6,3f800000,00000000,00000000,00000000,00000000,3f800000,00000000,00000000,00000000,00000000</hex>
   </filter>
-  <filter name="BPF_4_5" addr="1220">
-    <freq>100</freq>
+  <filter name="BPF_11_5" addr="1116">
+    <freq>12</freq>
     <q>0</q>
     <boost>0</boost>
-    <type>BWHPF_4</type>
-    <bypass>1</bypass>
-    <dec>0.9880089644550863,-1.9760179289101727,0.9880089644550863,1.975933280159253,-0.9761025776610925,0.9949731726667363,-1.9899463453334727,0.9949731726667363,1.9898610999163815,-0.9900315907505638,1,0,0,0,0,1,0,0,0,0</dec>
-    <hex>3f7cee28,bffcee28,3f7cee28,3ffceb62,bf79e1dc,3f7eb690,bffeb690,3f7eb690,3ffeb3c5,bf7d72b6,3f800000,00000000,00000000,00000000,00000000,3f800000,00000000,00000000,00000000,00000000</hex>
+    <type>LRHPF_8</type>
+    <bypass>0</bypass>
+    <dec>0.9985502610695056,-1.9971005221390112,0.9985502610695056,1.9970992902264981,-0.9971017540515243,0.9985502610695056,-1.9971005221390112,0.9985502610695056,1.9970992902264981,-0.9971017540515243,0.9993986271631015,-1.998797254326203,0.9993986271631015,1.9987960213670597,-0.998798487285346,0.9993986271631015,-1.998797254326203,0.9993986271631015,1.9987960213670597,-0.998798487285346</dec>
+    <hex>3f7fa0fd,bfffa0fd,3f7fa0fd,3fffa0f3,bf7f4210,3f7fa0fd,bfffa0fd,3f7fa0fd,3fffa0f3,bf7f4210,3f7fd897,bfffd897,3f7fd897,3fffd88c,bf7fb142,3f7fd897,bfffd897,3f7fd897,3fffd88c,bf7fb142</hex>
   </filter>
-  <filter name="PEQ_5_1" addr="1254">
+  <filter name="PEQ_12_1" addr="1150">
     <freq>20</freq>
     <q>0.707</q>
     <boost>0</boost>
@@ -2925,7 +3539,7 @@
     <dec>1,0,0,0,0</dec>
     <hex>3f800000,00000000,00000000,00000000,00000000</hex>
   </filter>
-  <filter name="PEQ_5_2" addr="1259">
+  <filter name="PEQ_12_2" addr="1155">
     <freq>40</freq>
     <q>0.707</q>
     <boost>0</boost>
@@ -2934,7 +3548,7 @@
     <dec>1,0,0,0,0</dec>
     <hex>3f800000,00000000,00000000,00000000,00000000</hex>
   </filter>
-  <filter name="PEQ_5_3" addr="1264">
+  <filter name="PEQ_12_3" addr="1160">
     <freq>80</freq>
     <q>0.707</q>
     <boost>0</boost>
@@ -2943,7 +3557,7 @@
     <dec>1,0,0,0,0</dec>
     <hex>3f800000,00000000,00000000,00000000,00000000</hex>
   </filter>
-  <filter name="PEQ_5_4" addr="1269">
+  <filter name="PEQ_12_4" addr="1165">
     <freq>160</freq>
     <q>0.707</q>
     <boost>0</boost>
@@ -2952,7 +3566,7 @@
     <dec>1,0,0,0,0</dec>
     <hex>3f800000,00000000,00000000,00000000,00000000</hex>
   </filter>
-  <filter name="PEQ_5_5" addr="1274">
+  <filter name="PEQ_12_5" addr="1170">
     <freq>320</freq>
     <q>0.707</q>
     <boost>0</boost>
@@ -2961,7 +3575,7 @@
     <dec>1,0,0,0,0</dec>
     <hex>3f800000,00000000,00000000,00000000,00000000</hex>
   </filter>
-  <filter name="PEQ_5_6" addr="1279">
+  <filter name="PEQ_12_6" addr="1175">
     <freq>640</freq>
     <q>0.707</q>
     <boost>0</boost>
@@ -2970,7 +3584,7 @@
     <dec>1,0,0,0,0</dec>
     <hex>3f800000,00000000,00000000,00000000,00000000</hex>
   </filter>
-  <filter name="PEQ_5_7" addr="1284">
+  <filter name="PEQ_12_7" addr="1180">
     <freq>1280</freq>
     <q>0.707</q>
     <boost>0</boost>
@@ -2979,7 +3593,7 @@
     <dec>1,0,0,0,0</dec>
     <hex>3f800000,00000000,00000000,00000000,00000000</hex>
   </filter>
-  <filter name="PEQ_5_8" addr="1289">
+  <filter name="PEQ_12_8" addr="1185">
     <freq>2560</freq>
     <q>0.707</q>
     <boost>0</boost>
@@ -2988,7 +3602,7 @@
     <dec>1,0,0,0,0</dec>
     <hex>3f800000,00000000,00000000,00000000,00000000</hex>
   </filter>
-  <filter name="PEQ_5_9" addr="1294">
+  <filter name="PEQ_12_9" addr="1190">
     <freq>5120</freq>
     <q>0.707</q>
     <boost>0</boost>
@@ -2997,7 +3611,7 @@
     <dec>1,0,0,0,0</dec>
     <hex>3f800000,00000000,00000000,00000000,00000000</hex>
   </filter>
-  <filter name="PEQ_5_10" addr="1299">
+  <filter name="PEQ_12_10" addr="1195">
     <freq>10240</freq>
     <q>0.707</q>
     <boost>0</boost>
@@ -3006,7 +3620,7 @@
     <dec>1,0,0,0,0</dec>
     <hex>3f800000,00000000,00000000,00000000,00000000</hex>
   </filter>
-  <filter name="BPF_5_1" addr="1304">
+  <filter name="BPF_12_1" addr="1200">
     <freq>100</freq>
     <q>0</q>
     <boost>0</boost>
@@ -3015,7 +3629,115 @@
     <dec>0.000042324375459811486,0.00008464875091962297,0.000042324375459811486,1.975933280159253,-0.9761025776610925,0.0000426227085455773,0.0000852454170911546,0.0000426227085455773,1.9898610999163815,-0.9900315907505638,1,0,0,0,0,1,0,0,0,0</dec>
     <hex>38318574,38b18574,38318574,3ffceb62,bf79e1dc,3832c5c9,38b2c5c9,3832c5c9,3ffeb3c5,bf7d72b6,3f800000,00000000,00000000,00000000,00000000,3f800000,00000000,00000000,00000000,00000000</hex>
   </filter>
-  <filter name="BPF_5_5" addr="1324">
+  <filter name="BPF_12_5" addr="1220">
+    <freq>12</freq>
+    <q>0</q>
+    <boost>0</boost>
+    <type>LRHPF_8</type>
+    <bypass>0</bypass>
+    <dec>0.9985502610695056,-1.9971005221390112,0.9985502610695056,1.9970992902264981,-0.9971017540515243,0.9985502610695056,-1.9971005221390112,0.9985502610695056,1.9970992902264981,-0.9971017540515243,0.9993986271631015,-1.998797254326203,0.9993986271631015,1.9987960213670597,-0.998798487285346,0.9993986271631015,-1.998797254326203,0.9993986271631015,1.9987960213670597,-0.998798487285346</dec>
+    <hex>3f7fa0fd,bfffa0fd,3f7fa0fd,3fffa0f3,bf7f4210,3f7fa0fd,bfffa0fd,3f7fa0fd,3fffa0f3,bf7f4210,3f7fd897,bfffd897,3f7fd897,3fffd88c,bf7fb142,3f7fd897,bfffd897,3f7fd897,3fffd88c,bf7fb142</hex>
+  </filter>
+  <filter name="PEQ_13_1" addr="1254">
+    <freq>10</freq>
+    <q>0.5</q>
+    <boost>4.4</boost>
+    <type>SL</type>
+    <bypass>0</bypass>
+    <dec>1.0003322714626963,-1.997694310281361,0.9973642436565501,1.9976947484272018,-0.9976960769734053</dec>
+    <hex>3f800ae3,bfffb472,3f7f5343,3fffb476,bf7f6903</hex>
+  </filter>
+  <filter name="PEQ_13_2" addr="1259">
+    <freq>40</freq>
+    <q>0.707</q>
+    <boost>0</boost>
+    <type>PK</type>
+    <bypass>0</bypass>
+    <dec>1,0,0,0,0</dec>
+    <hex>3f800000,00000000,00000000,00000000,00000000</hex>
+  </filter>
+  <filter name="PEQ_13_3" addr="1264">
+    <freq>80</freq>
+    <q>0.707</q>
+    <boost>0</boost>
+    <type>PK</type>
+    <bypass>0</bypass>
+    <dec>1,0,0,0,0</dec>
+    <hex>3f800000,00000000,00000000,00000000,00000000</hex>
+  </filter>
+  <filter name="PEQ_13_4" addr="1269">
+    <freq>160</freq>
+    <q>0.707</q>
+    <boost>0</boost>
+    <type>PK</type>
+    <bypass>0</bypass>
+    <dec>1,0,0,0,0</dec>
+    <hex>3f800000,00000000,00000000,00000000,00000000</hex>
+  </filter>
+  <filter name="PEQ_13_5" addr="1274">
+    <freq>320</freq>
+    <q>0.707</q>
+    <boost>0</boost>
+    <type>PK</type>
+    <bypass>0</bypass>
+    <dec>1,0,0,0,0</dec>
+    <hex>3f800000,00000000,00000000,00000000,00000000</hex>
+  </filter>
+  <filter name="PEQ_13_6" addr="1279">
+    <freq>640</freq>
+    <q>0.707</q>
+    <boost>0</boost>
+    <type>PK</type>
+    <bypass>0</bypass>
+    <dec>1,0,0,0,0</dec>
+    <hex>3f800000,00000000,00000000,00000000,00000000</hex>
+  </filter>
+  <filter name="PEQ_13_7" addr="1284">
+    <freq>1280</freq>
+    <q>0.707</q>
+    <boost>0</boost>
+    <type>PK</type>
+    <bypass>0</bypass>
+    <dec>1,0,0,0,0</dec>
+    <hex>3f800000,00000000,00000000,00000000,00000000</hex>
+  </filter>
+  <filter name="PEQ_13_8" addr="1289">
+    <freq>2560</freq>
+    <q>0.707</q>
+    <boost>0</boost>
+    <type>PK</type>
+    <bypass>0</bypass>
+    <dec>1,0,0,0,0</dec>
+    <hex>3f800000,00000000,00000000,00000000,00000000</hex>
+  </filter>
+  <filter name="PEQ_13_9" addr="1294">
+    <freq>5120</freq>
+    <q>0.707</q>
+    <boost>0</boost>
+    <type>PK</type>
+    <bypass>0</bypass>
+    <dec>1,0,0,0,0</dec>
+    <hex>3f800000,00000000,00000000,00000000,00000000</hex>
+  </filter>
+  <filter name="PEQ_13_10" addr="1299">
+    <freq>10240</freq>
+    <q>0.707</q>
+    <boost>0</boost>
+    <type>PK</type>
+    <bypass>0</bypass>
+    <dec>1,0,0,0,0</dec>
+    <hex>3f800000,00000000,00000000,00000000,00000000</hex>
+  </filter>
+  <filter name="BPF_13_1" addr="1304">
+    <freq>30</freq>
+    <q>0</q>
+    <boost>0</boost>
+    <type>LRLPF_4</type>
+    <bypass>0</bypass>
+    <dec>0.000003844633506776048,0.000007689267013552096,0.000003844633506776048,1.9944464105402575,-0.9944617890742847,0.000003844633506776048,0.000007689267013552096,0.000003844633506776048,1.9944464105402575,-0.9944617890742847,1,0,0,0,0,1,0,0,0,0</dec>
+    <hex>36810126,37010126,36810126,3fff4a05,bf7e950c,36810126,37010126,36810126,3fff4a05,bf7e950c,3f800000,00000000,00000000,00000000,00000000,3f800000,00000000,00000000,00000000,00000000</hex>
+  </filter>
+  <filter name="BPF_13_5" addr="1324">
     <freq>100</freq>
     <q>0</q>
     <boost>0</boost>
@@ -3024,16 +3746,16 @@
     <dec>0.9880089644550863,-1.9760179289101727,0.9880089644550863,1.975933280159253,-0.9761025776610925,0.9949731726667363,-1.9899463453334727,0.9949731726667363,1.9898610999163815,-0.9900315907505638,1,0,0,0,0,1,0,0,0,0</dec>
     <hex>3f7cee28,bffcee28,3f7cee28,3ffceb62,bf79e1dc,3f7eb690,bffeb690,3f7eb690,3ffeb3c5,bf7d72b6,3f800000,00000000,00000000,00000000,00000000,3f800000,00000000,00000000,00000000,00000000</hex>
   </filter>
-  <filter name="PEQ_6_1" addr="1358">
-    <freq>20</freq>
-    <q>0.707</q>
-    <boost>0</boost>
-    <type>PK</type>
+  <filter name="PEQ_14_1" addr="1358">
+    <freq>10</freq>
+    <q>0.5</q>
+    <boost>4.4</boost>
+    <type>SL</type>
     <bypass>0</bypass>
-    <dec>1,0,0,0,0</dec>
-    <hex>3f800000,00000000,00000000,00000000,00000000</hex>
+    <dec>1.0003322714626963,-1.997694310281361,0.9973642436565501,1.9976947484272018,-0.9976960769734053</dec>
+    <hex>3f800ae3,bfffb472,3f7f5343,3fffb476,bf7f6903</hex>
   </filter>
-  <filter name="PEQ_6_2" addr="1363">
+  <filter name="PEQ_14_2" addr="1363">
     <freq>40</freq>
     <q>0.707</q>
     <boost>0</boost>
@@ -3042,7 +3764,7 @@
     <dec>1,0,0,0,0</dec>
     <hex>3f800000,00000000,00000000,00000000,00000000</hex>
   </filter>
-  <filter name="PEQ_6_3" addr="1368">
+  <filter name="PEQ_14_3" addr="1368">
     <freq>80</freq>
     <q>0.707</q>
     <boost>0</boost>
@@ -3051,7 +3773,7 @@
     <dec>1,0,0,0,0</dec>
     <hex>3f800000,00000000,00000000,00000000,00000000</hex>
   </filter>
-  <filter name="PEQ_6_4" addr="1373">
+  <filter name="PEQ_14_4" addr="1373">
     <freq>160</freq>
     <q>0.707</q>
     <boost>0</boost>
@@ -3060,7 +3782,7 @@
     <dec>1,0,0,0,0</dec>
     <hex>3f800000,00000000,00000000,00000000,00000000</hex>
   </filter>
-  <filter name="PEQ_6_5" addr="1378">
+  <filter name="PEQ_14_5" addr="1378">
     <freq>320</freq>
     <q>0.707</q>
     <boost>0</boost>
@@ -3069,7 +3791,7 @@
     <dec>1,0,0,0,0</dec>
     <hex>3f800000,00000000,00000000,00000000,00000000</hex>
   </filter>
-  <filter name="PEQ_6_6" addr="1383">
+  <filter name="PEQ_14_6" addr="1383">
     <freq>640</freq>
     <q>0.707</q>
     <boost>0</boost>
@@ -3078,7 +3800,7 @@
     <dec>1,0,0,0,0</dec>
     <hex>3f800000,00000000,00000000,00000000,00000000</hex>
   </filter>
-  <filter name="PEQ_6_7" addr="1388">
+  <filter name="PEQ_14_7" addr="1388">
     <freq>1280</freq>
     <q>0.707</q>
     <boost>0</boost>
@@ -3087,7 +3809,7 @@
     <dec>1,0,0,0,0</dec>
     <hex>3f800000,00000000,00000000,00000000,00000000</hex>
   </filter>
-  <filter name="PEQ_6_8" addr="1393">
+  <filter name="PEQ_14_8" addr="1393">
     <freq>2560</freq>
     <q>0.707</q>
     <boost>0</boost>
@@ -3096,7 +3818,7 @@
     <dec>1,0,0,0,0</dec>
     <hex>3f800000,00000000,00000000,00000000,00000000</hex>
   </filter>
-  <filter name="PEQ_6_9" addr="1398">
+  <filter name="PEQ_14_9" addr="1398">
     <freq>5120</freq>
     <q>0.707</q>
     <boost>0</boost>
@@ -3105,7 +3827,7 @@
     <dec>1,0,0,0,0</dec>
     <hex>3f800000,00000000,00000000,00000000,00000000</hex>
   </filter>
-  <filter name="PEQ_6_10" addr="1403">
+  <filter name="PEQ_14_10" addr="1403">
     <freq>10240</freq>
     <q>0.707</q>
     <boost>0</boost>
@@ -3114,16 +3836,16 @@
     <dec>1,0,0,0,0</dec>
     <hex>3f800000,00000000,00000000,00000000,00000000</hex>
   </filter>
-  <filter name="BPF_6_1" addr="1408">
-    <freq>100</freq>
+  <filter name="BPF_14_1" addr="1408">
+    <freq>30</freq>
     <q>0</q>
     <boost>0</boost>
-    <type>BWLPF_4</type>
-    <bypass>1</bypass>
-    <dec>0.000042324375459811486,0.00008464875091962297,0.000042324375459811486,1.975933280159253,-0.9761025776610925,0.0000426227085455773,0.0000852454170911546,0.0000426227085455773,1.9898610999163815,-0.9900315907505638,1,0,0,0,0,1,0,0,0,0</dec>
-    <hex>38318574,38b18574,38318574,3ffceb62,bf79e1dc,3832c5c9,38b2c5c9,3832c5c9,3ffeb3c5,bf7d72b6,3f800000,00000000,00000000,00000000,00000000,3f800000,00000000,00000000,00000000,00000000</hex>
+    <type>LRLPF_4</type>
+    <bypass>0</bypass>
+    <dec>0.000003844633506776048,0.000007689267013552096,0.000003844633506776048,1.9944464105402575,-0.9944617890742847,0.000003844633506776048,0.000007689267013552096,0.000003844633506776048,1.9944464105402575,-0.9944617890742847,1,0,0,0,0,1,0,0,0,0</dec>
+    <hex>36810126,37010126,36810126,3fff4a05,bf7e950c,36810126,37010126,36810126,3fff4a05,bf7e950c,3f800000,00000000,00000000,00000000,00000000,3f800000,00000000,00000000,00000000,00000000</hex>
   </filter>
-  <filter name="BPF_6_5" addr="1428">
+  <filter name="BPF_14_5" addr="1428">
     <freq>100</freq>
     <q>0</q>
     <boost>0</boost>
@@ -3132,34 +3854,34 @@
     <dec>0.9880089644550863,-1.9760179289101727,0.9880089644550863,1.975933280159253,-0.9761025776610925,0.9949731726667363,-1.9899463453334727,0.9949731726667363,1.9898610999163815,-0.9900315907505638,1,0,0,0,0,1,0,0,0,0</dec>
     <hex>3f7cee28,bffcee28,3f7cee28,3ffceb62,bf79e1dc,3f7eb690,bffeb690,3f7eb690,3ffeb3c5,bf7d72b6,3f800000,00000000,00000000,00000000,00000000,3f800000,00000000,00000000,00000000,00000000</hex>
   </filter>
-  <filter name="PEQ_7_1" addr="1462">
+  <filter name="PEQ_15_1" addr="1462">
     <freq>20</freq>
-    <q>0.7</q>
+    <q>0.707</q>
     <boost>0</boost>
-    <type>adv</type>
+    <type>PK</type>
     <bypass>0</bypass>
-    <dec>0.99960486240858,-1.998157798669569,0.998810825328149,1.998157798669569,-0.998415687736728</dec>
-    <hex>3f7fe61b,bfffc3a2,3f7fb211,3fffc3a2,bf7f982c</hex>
+    <dec>1,0,0,0,0</dec>
+    <hex>3f800000,00000000,00000000,00000000,00000000</hex>
   </filter>
-  <filter name="PEQ_7_2" addr="1467">
+  <filter name="PEQ_15_2" addr="1467">
     <freq>40</freq>
     <q>0.707</q>
     <boost>0</boost>
-    <type>adv</type>
+    <type>PK</type>
     <bypass>0</bypass>
-    <dec>0.999789760652378,-1.999055489270042,0.999367280378666,1.999055489270042,-0.999157041031044</dec>
-    <hex>3f7ff239,bfffe10d,3f7fd689,3fffe10d,bf7fc8c1</hex>
+    <dec>1,0,0,0,0</dec>
+    <hex>3f800000,00000000,00000000,00000000,00000000</hex>
   </filter>
-  <filter name="PEQ_7_3" addr="1472">
+  <filter name="PEQ_15_3" addr="1472">
     <freq>80</freq>
     <q>0.707</q>
     <boost>0</boost>
-    <type>adv</type>
+    <type>PK</type>
     <bypass>0</bypass>
-    <dec>0.999703168509582,-1.998781598859449,0.999106679551941,1.998781598859449,-0.998809848061523</dec>
-    <hex>3f7fec8c,bfffd813,3f7fc575,3fffd813,bf7fb201</hex>
+    <dec>1,0,0,0,0</dec>
+    <hex>3f800000,00000000,00000000,00000000,00000000</hex>
   </filter>
-  <filter name="PEQ_7_4" addr="1477">
+  <filter name="PEQ_15_4" addr="1477">
     <freq>160</freq>
     <q>0.707</q>
     <boost>0</boost>
@@ -3168,7 +3890,7 @@
     <dec>1,0,0,0,0</dec>
     <hex>3f800000,00000000,00000000,00000000,00000000</hex>
   </filter>
-  <filter name="PEQ_7_5" addr="1482">
+  <filter name="PEQ_15_5" addr="1482">
     <freq>320</freq>
     <q>0.707</q>
     <boost>0</boost>
@@ -3177,7 +3899,7 @@
     <dec>1,0,0,0,0</dec>
     <hex>3f800000,00000000,00000000,00000000,00000000</hex>
   </filter>
-  <filter name="PEQ_7_6" addr="1487">
+  <filter name="PEQ_15_6" addr="1487">
     <freq>640</freq>
     <q>0.707</q>
     <boost>0</boost>
@@ -3186,7 +3908,7 @@
     <dec>1,0,0,0,0</dec>
     <hex>3f800000,00000000,00000000,00000000,00000000</hex>
   </filter>
-  <filter name="PEQ_7_7" addr="1492">
+  <filter name="PEQ_15_7" addr="1492">
     <freq>1280</freq>
     <q>0.707</q>
     <boost>0</boost>
@@ -3195,7 +3917,7 @@
     <dec>1,0,0,0,0</dec>
     <hex>3f800000,00000000,00000000,00000000,00000000</hex>
   </filter>
-  <filter name="PEQ_7_8" addr="1497">
+  <filter name="PEQ_15_8" addr="1497">
     <freq>2560</freq>
     <q>0.707</q>
     <boost>0</boost>
@@ -3204,7 +3926,7 @@
     <dec>1,0,0,0,0</dec>
     <hex>3f800000,00000000,00000000,00000000,00000000</hex>
   </filter>
-  <filter name="PEQ_7_9" addr="1502">
+  <filter name="PEQ_15_9" addr="1502">
     <freq>5120</freq>
     <q>0.707</q>
     <boost>0</boost>
@@ -3213,7 +3935,7 @@
     <dec>1,0,0,0,0</dec>
     <hex>3f800000,00000000,00000000,00000000,00000000</hex>
   </filter>
-  <filter name="PEQ_7_10" addr="1507">
+  <filter name="PEQ_15_10" addr="1507">
     <freq>10240</freq>
     <q>0.707</q>
     <boost>0</boost>
@@ -3222,7 +3944,7 @@
     <dec>1,0,0,0,0</dec>
     <hex>3f800000,00000000,00000000,00000000,00000000</hex>
   </filter>
-  <filter name="BPF_7_1" addr="1512">
+  <filter name="BPF_15_1" addr="1512">
     <freq>100</freq>
     <q>0</q>
     <boost>0</boost>
@@ -3231,7 +3953,7 @@
     <dec>0.000042324375459811486,0.00008464875091962297,0.000042324375459811486,1.975933280159253,-0.9761025776610925,0.0000426227085455773,0.0000852454170911546,0.0000426227085455773,1.9898610999163815,-0.9900315907505638,1,0,0,0,0,1,0,0,0,0</dec>
     <hex>38318574,38b18574,38318574,3ffceb62,bf79e1dc,3832c5c9,38b2c5c9,3832c5c9,3ffeb3c5,bf7d72b6,3f800000,00000000,00000000,00000000,00000000,3f800000,00000000,00000000,00000000,00000000</hex>
   </filter>
-  <filter name="BPF_7_5" addr="1532">
+  <filter name="BPF_15_5" addr="1532">
     <freq>100</freq>
     <q>0</q>
     <boost>0</boost>
@@ -3240,34 +3962,34 @@
     <dec>0.9880089644550863,-1.9760179289101727,0.9880089644550863,1.975933280159253,-0.9761025776610925,0.9949731726667363,-1.9899463453334727,0.9949731726667363,1.9898610999163815,-0.9900315907505638,1,0,0,0,0,1,0,0,0,0</dec>
     <hex>3f7cee28,bffcee28,3f7cee28,3ffceb62,bf79e1dc,3f7eb690,bffeb690,3f7eb690,3ffeb3c5,bf7d72b6,3f800000,00000000,00000000,00000000,00000000,3f800000,00000000,00000000,00000000,00000000</hex>
   </filter>
-  <filter name="PEQ_8_1" addr="1566">
+  <filter name="PEQ_16_1" addr="1566">
     <freq>20</freq>
-    <q>0.7</q>
+    <q>0.707</q>
     <boost>0</boost>
-    <type>adv</type>
+    <type>PK</type>
     <bypass>0</bypass>
-    <dec>0.9988061851238,-1.995206537325895,0.996407189686629,1.995206537325895,-0.995213374810429</dec>
-    <hex>3f7fb1c3,bfff62ee,3f7f148b,3fff62ee,bf7ec64e</hex>
+    <dec>1,0,0,0,0</dec>
+    <hex>3f800000,00000000,00000000,00000000,00000000</hex>
   </filter>
-  <filter name="PEQ_8_2" addr="1571">
+  <filter name="PEQ_16_2" addr="1571">
     <freq>40</freq>
     <q>0.707</q>
     <boost>0</boost>
-    <type>adv</type>
+    <type>PK</type>
     <bypass>0</bypass>
-    <dec>0.998661560780939,-1.994425541819511,0.995971939765593,1.994425541819511,-0.994633500546532</dec>
-    <hex>3f7fa849,bfff4956,3f7ef804,3fff4956,bf7ea04d</hex>
+    <dec>1,0,0,0,0</dec>
+    <hex>3f800000,00000000,00000000,00000000,00000000</hex>
   </filter>
-  <filter name="PEQ_8_3" addr="1576">
+  <filter name="PEQ_16_3" addr="1576">
     <freq>80</freq>
     <q>0.707</q>
     <boost>0</boost>
-    <type>adv</type>
+    <type>PK</type>
     <bypass>0</bypass>
-    <dec>0.998806185134288,-1.995206537367946,0.996407189718192,1.995206537367946,-0.99521337485248</dec>
-    <hex>3f7fb1c3,bfff62ee,3f7f148b,3fff62ee,bf7ec64e</hex>
+    <dec>1,0,0,0,0</dec>
+    <hex>3f800000,00000000,00000000,00000000,00000000</hex>
   </filter>
-  <filter name="PEQ_8_4" addr="1581">
+  <filter name="PEQ_16_4" addr="1581">
     <freq>160</freq>
     <q>0.707</q>
     <boost>0</boost>
@@ -3276,7 +3998,7 @@
     <dec>1,0,0,0,0</dec>
     <hex>3f800000,00000000,00000000,00000000,00000000</hex>
   </filter>
-  <filter name="PEQ_8_5" addr="1586">
+  <filter name="PEQ_16_5" addr="1586">
     <freq>320</freq>
     <q>0.707</q>
     <boost>0</boost>
@@ -3285,7 +4007,7 @@
     <dec>1,0,0,0,0</dec>
     <hex>3f800000,00000000,00000000,00000000,00000000</hex>
   </filter>
-  <filter name="PEQ_8_6" addr="1591">
+  <filter name="PEQ_16_6" addr="1591">
     <freq>640</freq>
     <q>0.707</q>
     <boost>0</boost>
@@ -3294,7 +4016,7 @@
     <dec>1,0,0,0,0</dec>
     <hex>3f800000,00000000,00000000,00000000,00000000</hex>
   </filter>
-  <filter name="PEQ_8_7" addr="1596">
+  <filter name="PEQ_16_7" addr="1596">
     <freq>1280</freq>
     <q>0.707</q>
     <boost>0</boost>
@@ -3303,7 +4025,7 @@
     <dec>1,0,0,0,0</dec>
     <hex>3f800000,00000000,00000000,00000000,00000000</hex>
   </filter>
-  <filter name="PEQ_8_8" addr="1601">
+  <filter name="PEQ_16_8" addr="1601">
     <freq>2560</freq>
     <q>0.707</q>
     <boost>0</boost>
@@ -3312,7 +4034,7 @@
     <dec>1,0,0,0,0</dec>
     <hex>3f800000,00000000,00000000,00000000,00000000</hex>
   </filter>
-  <filter name="PEQ_8_9" addr="1606">
+  <filter name="PEQ_16_9" addr="1606">
     <freq>5120</freq>
     <q>0.707</q>
     <boost>0</boost>
@@ -3321,7 +4043,7 @@
     <dec>1,0,0,0,0</dec>
     <hex>3f800000,00000000,00000000,00000000,00000000</hex>
   </filter>
-  <filter name="PEQ_8_10" addr="1611">
+  <filter name="PEQ_16_10" addr="1611">
     <freq>10240</freq>
     <q>0.707</q>
     <boost>0</boost>
@@ -3330,7 +4052,7 @@
     <dec>1,0,0,0,0</dec>
     <hex>3f800000,00000000,00000000,00000000,00000000</hex>
   </filter>
-  <filter name="BPF_8_1" addr="1616">
+  <filter name="BPF_16_1" addr="1616">
     <freq>100</freq>
     <q>0</q>
     <boost>0</boost>
@@ -3339,7 +4061,7 @@
     <dec>0.000042324375459811486,0.00008464875091962297,0.000042324375459811486,1.975933280159253,-0.9761025776610925,0.0000426227085455773,0.0000852454170911546,0.0000426227085455773,1.9898610999163815,-0.9900315907505638,1,0,0,0,0,1,0,0,0,0</dec>
     <hex>38318574,38b18574,38318574,3ffceb62,bf79e1dc,3832c5c9,38b2c5c9,3832c5c9,3ffeb3c5,bf7d72b6,3f800000,00000000,00000000,00000000,00000000,3f800000,00000000,00000000,00000000,00000000</hex>
   </filter>
-  <filter name="BPF_8_5" addr="1636">
+  <filter name="BPF_16_5" addr="1636">
     <freq>100</freq>
     <q>0</q>
     <boost>0</boost>

--- a/devtools/src/codegen/flexhtx/mod.rs
+++ b/devtools/src/codegen/flexhtx/mod.rs
@@ -27,48 +27,35 @@ pub(crate) fn input(input: usize) -> Input {
         }),
         meter: Some(format!("Meter_In_{}", input + 1)),
         //meter_d: Some(format!("Meter_D_In_{}", input + 1)),
-        peq: vec![], //no input peq
-        /*bass_management: Some(Gate {
-            enable: format!("BM_DGain_{}_status", 3 + output),
-            gain: Some(format!("BM_DGain_{}", 3 + output)),
-        }),*/
+        peq: (1..=10usize)
+            .rev()
+            .map(|index| format!("PEQ_{}_{}", input + 1, index))
+            .collect(),
         routing: (0..8usize)
             .map(|output| Gate {
                 enable: format!("BM_Mixer_{}_{}_status", input + 1, output + 1),
                 gain: Some(format!("BM_Mixer_{}_{}", input + 1, output + 1)),
-                //polarity: Some(format!("BM_Mixer_{input}_{output}_pol")),
             })
             .collect(),
     }
 }
 
 pub(crate) fn output(output: usize) -> Output {
+    let ch = 9 + output;
+
     Output {
         gate: Gate {
-            enable: format!("DGain_{}_0_status", output + 1),
-            gain: Some(format!("DGain_{}_0", output + 1)),
+            enable: format!("DGain_{}_0_status", ch),
+            gain: Some(format!("DGain_{}_0", ch)),
         },
-        /*routing: (0..7usize) //input number
-        .map(|input| Gate {
-            enable: format!("Out_Mixer_{input}_{output}_status"),
-            gain: Some(format!("Out_Mixer_{input}_{output}")),
-            polarity: Some(format!("Out_Mixer_{input}_{output}_pol")),
-        })
-        .collect(),*/
-        meter: Some(format!("Meter_Out_{}", output + 1)), /*  (0..2usize)
-                                                          .map(|ind| Some(format!("Meter_{}_{}", 1 + output, ind)))
-                                                          .collect(),*/
-        //meter_d: Some(format!("Meter_D_Out_{}", output + 1)),
-        delay_addr: Some(format!("Delay_{}_0", 1 + output)),
-        invert_addr: format!("polarity_out_{}_0", 1 + output),
-        peq: (1..=10usize)
-            .rev()
-            .map(|index| format!("PEQ_{}_{}", output + 1, index))
-            .collect(),
+        meter: Some(format!("Meter_Out_{}", ch)),
+        delay_addr: Some(format!("Delay_{}_0", ch)),
+        invert_addr: format!("polarity_out_{}_0", ch),
+        peq: vec![],
         xover: Some(Crossover {
             peqs: [1, 5]
                 .iter()
-                .map(|group| format!("BPF_{}_{}", output + 1, group))
+                .map(|group| format!("BPF_{}_{}", ch, group))
                 .chain(
                     [1, 5]
                         .iter()
@@ -77,13 +64,12 @@ pub(crate) fn output(output: usize) -> Output {
                 .collect(),
         }),
         compressor: Some(Compressor {
-            bypass: format!("COMP_{}_0_status", output + 1),
-            threshold: format!("COMP_{}_0_threshold", output + 1),
-            ratio: format!("COMP_{}_0_ratio", output + 1),
-            //knee: Some(format!("COMP_{}_0_knee", output + 1)),
-            attack: format!("COMP_{}_0_atime", output + 1),
-            release: format!("COMP_{}_0_rtime", output + 1),
-            meter: Some(format!("Meter_Comp_{}", output + 1)),
+            bypass: format!("COMP_{}_0_status", ch),
+            threshold: format!("COMP_{}_0_threshold", ch),
+            ratio: format!("COMP_{}_0_ratio", ch),
+            attack: format!("COMP_{}_0_atime", ch),
+            release: format!("COMP_{}_0_rtime", ch),
+            meter: Some(format!("Meter_Comp_{}", ch)),
         }),
         fir: None,
     }

--- a/protocol/src/device/flexhtx.rs
+++ b/protocol/src/device/flexhtx.rs
@@ -470,230 +470,310 @@ pub mod sym {
     pub const METER_D_OUT_6: u16 = 805;
     pub const METER_D_OUT_7: u16 = 806;
     pub const METER_D_OUT_8: u16 = 807;
-    pub const METER_COMP_1: u16 = 808;
-    pub const METER_COMP_2: u16 = 809;
-    pub const METER_COMP_3: u16 = 810;
-    pub const METER_COMP_4: u16 = 811;
-    pub const METER_COMP_5: u16 = 812;
-    pub const METER_COMP_6: u16 = 813;
-    pub const METER_COMP_7: u16 = 814;
-    pub const METER_COMP_8: u16 = 815;
-    pub const METER_OUT_1: u16 = 816;
-    pub const METER_OUT_2: u16 = 817;
-    pub const METER_OUT_3: u16 = 818;
-    pub const METER_OUT_4: u16 = 819;
-    pub const METER_OUT_5: u16 = 820;
-    pub const METER_OUT_6: u16 = 821;
-    pub const METER_OUT_7: u16 = 822;
-    pub const METER_OUT_8: u16 = 823;
-    pub const D_GAIN_1_0_STATUS: u16 = 824;
-    pub const COMP_1_0_STATUS: u16 = 825;
-    pub const D_GAIN_1_0: u16 = 826;
-    pub const COMP_1_0_THRESHOLD: u16 = 827;
-    pub const COMP_1_0_GAIN: u16 = 828;
-    pub const COMP_1_0_RATIO: u16 = 829;
-    pub const COMP_1_0_KNEE: u16 = 830;
-    pub const COMP_1_0_ATIME: u16 = 831;
-    pub const COMP_1_0_RTIME: u16 = 832;
-    pub const DELAY_1_0: u16 = 833;
+    pub const METER_COMP_9: u16 = 808;
+    pub const METER_COMP_10: u16 = 809;
+    pub const METER_COMP_11: u16 = 810;
+    pub const METER_COMP_12: u16 = 811;
+    pub const METER_COMP_13: u16 = 812;
+    pub const METER_COMP_14: u16 = 813;
+    pub const METER_COMP_15: u16 = 814;
+    pub const METER_COMP_16: u16 = 815;
+    pub const METER_OUT_9: u16 = 816;
+    pub const METER_OUT_10: u16 = 817;
+    pub const METER_OUT_11: u16 = 818;
+    pub const METER_OUT_12: u16 = 819;
+    pub const METER_OUT_13: u16 = 820;
+    pub const METER_OUT_14: u16 = 821;
+    pub const METER_OUT_15: u16 = 822;
+    pub const METER_OUT_16: u16 = 823;
+    pub const D_GAIN_9_0_STATUS: u16 = 824;
+    pub const COMP_9_0_STATUS: u16 = 825;
+    pub const D_GAIN_9_0: u16 = 826;
+    pub const COMP_9_0_THRESHOLD: u16 = 827;
+    pub const COMP_9_0_GAIN: u16 = 828;
+    pub const COMP_9_0_RATIO: u16 = 829;
+    pub const COMP_9_0_KNEE: u16 = 830;
+    pub const COMP_9_0_ATIME: u16 = 831;
+    pub const COMP_9_0_RTIME: u16 = 832;
+    pub const DELAY_9_0: u16 = 833;
     pub const METER_1_0: u16 = 834;
     pub const METER_1_1: u16 = 835;
     pub const METER_1_2: u16 = 836;
-    pub const POLARITY_OUT_1_0: u16 = 837;
-    pub const PEQ_1_1: u16 = 838;
-    pub const PEQ_1_2: u16 = 843;
-    pub const PEQ_1_3: u16 = 848;
-    pub const PEQ_1_4: u16 = 853;
-    pub const PEQ_1_5: u16 = 858;
-    pub const PEQ_1_6: u16 = 863;
-    pub const PEQ_1_7: u16 = 868;
-    pub const PEQ_1_8: u16 = 873;
-    pub const PEQ_1_9: u16 = 878;
-    pub const PEQ_1_10: u16 = 883;
-    pub const BPF_1_1: u16 = 888;
-    pub const BPF_1_5: u16 = 908;
-    pub const D_GAIN_2_0_STATUS: u16 = 928;
-    pub const COMP_2_0_STATUS: u16 = 929;
-    pub const D_GAIN_2_0: u16 = 930;
-    pub const COMP_2_0_THRESHOLD: u16 = 931;
-    pub const COMP_2_0_GAIN: u16 = 932;
-    pub const COMP_2_0_RATIO: u16 = 933;
-    pub const COMP_2_0_KNEE: u16 = 934;
-    pub const COMP_2_0_ATIME: u16 = 935;
-    pub const COMP_2_0_RTIME: u16 = 936;
-    pub const DELAY_2_0: u16 = 937;
+    pub const POLARITY_OUT_9_0: u16 = 837;
+    pub const PEQ_9_1: u16 = 838;
+    pub const PEQ_9_2: u16 = 843;
+    pub const PEQ_9_3: u16 = 848;
+    pub const PEQ_9_4: u16 = 853;
+    pub const PEQ_9_5: u16 = 858;
+    pub const PEQ_9_6: u16 = 863;
+    pub const PEQ_9_7: u16 = 868;
+    pub const PEQ_9_8: u16 = 873;
+    pub const PEQ_9_9: u16 = 878;
+    pub const PEQ_9_10: u16 = 883;
+    pub const BPF_9_1: u16 = 888;
+    pub const BPF_9_5: u16 = 908;
+    pub const D_GAIN_10_0_STATUS: u16 = 928;
+    pub const COMP_10_0_STATUS: u16 = 929;
+    pub const D_GAIN_10_0: u16 = 930;
+    pub const COMP_10_0_THRESHOLD: u16 = 931;
+    pub const COMP_10_0_GAIN: u16 = 932;
+    pub const COMP_10_0_RATIO: u16 = 933;
+    pub const COMP_10_0_KNEE: u16 = 934;
+    pub const COMP_10_0_ATIME: u16 = 935;
+    pub const COMP_10_0_RTIME: u16 = 936;
+    pub const DELAY_10_0: u16 = 937;
     pub const METER_2_0: u16 = 938;
     pub const METER_2_1: u16 = 939;
     pub const METER_2_2: u16 = 940;
-    pub const POLARITY_OUT_2_0: u16 = 941;
-    pub const PEQ_2_1: u16 = 942;
-    pub const PEQ_2_2: u16 = 947;
-    pub const PEQ_2_3: u16 = 952;
-    pub const PEQ_2_4: u16 = 957;
-    pub const PEQ_2_5: u16 = 962;
-    pub const PEQ_2_6: u16 = 967;
-    pub const PEQ_2_7: u16 = 972;
-    pub const PEQ_2_8: u16 = 977;
-    pub const PEQ_2_9: u16 = 982;
-    pub const PEQ_2_10: u16 = 987;
-    pub const BPF_2_1: u16 = 992;
-    pub const BPF_2_5: u16 = 1012;
-    pub const D_GAIN_3_0_STATUS: u16 = 1032;
-    pub const COMP_3_0_STATUS: u16 = 1033;
-    pub const D_GAIN_3_0: u16 = 1034;
-    pub const COMP_3_0_THRESHOLD: u16 = 1035;
-    pub const COMP_3_0_GAIN: u16 = 1036;
-    pub const COMP_3_0_RATIO: u16 = 1037;
-    pub const COMP_3_0_KNEE: u16 = 1038;
-    pub const COMP_3_0_ATIME: u16 = 1039;
-    pub const COMP_3_0_RTIME: u16 = 1040;
-    pub const DELAY_3_0: u16 = 1041;
+    pub const POLARITY_OUT_10_0: u16 = 941;
+    pub const PEQ_10_1: u16 = 942;
+    pub const PEQ_10_2: u16 = 947;
+    pub const PEQ_10_3: u16 = 952;
+    pub const PEQ_10_4: u16 = 957;
+    pub const PEQ_10_5: u16 = 962;
+    pub const PEQ_10_6: u16 = 967;
+    pub const PEQ_10_7: u16 = 972;
+    pub const PEQ_10_8: u16 = 977;
+    pub const PEQ_10_9: u16 = 982;
+    pub const PEQ_10_10: u16 = 987;
+    pub const BPF_10_1: u16 = 992;
+    pub const BPF_10_5: u16 = 1012;
+    pub const D_GAIN_11_0_STATUS: u16 = 1032;
+    pub const COMP_11_0_STATUS: u16 = 1033;
+    pub const D_GAIN_11_0: u16 = 1034;
+    pub const COMP_11_0_THRESHOLD: u16 = 1035;
+    pub const COMP_11_0_GAIN: u16 = 1036;
+    pub const COMP_11_0_RATIO: u16 = 1037;
+    pub const COMP_11_0_KNEE: u16 = 1038;
+    pub const COMP_11_0_ATIME: u16 = 1039;
+    pub const COMP_11_0_RTIME: u16 = 1040;
+    pub const DELAY_11_0: u16 = 1041;
     pub const METER_3_0: u16 = 1042;
     pub const METER_3_1: u16 = 1043;
     pub const METER_3_2: u16 = 1044;
-    pub const POLARITY_OUT_3_0: u16 = 1045;
-    pub const PEQ_3_1: u16 = 1046;
-    pub const PEQ_3_2: u16 = 1051;
-    pub const PEQ_3_3: u16 = 1056;
-    pub const PEQ_3_4: u16 = 1061;
-    pub const PEQ_3_5: u16 = 1066;
-    pub const PEQ_3_6: u16 = 1071;
-    pub const PEQ_3_7: u16 = 1076;
-    pub const PEQ_3_8: u16 = 1081;
-    pub const PEQ_3_9: u16 = 1086;
-    pub const PEQ_3_10: u16 = 1091;
-    pub const BPF_3_1: u16 = 1096;
-    pub const BPF_3_5: u16 = 1116;
-    pub const D_GAIN_4_0_STATUS: u16 = 1136;
-    pub const COMP_4_0_STATUS: u16 = 1137;
-    pub const D_GAIN_4_0: u16 = 1138;
-    pub const COMP_4_0_THRESHOLD: u16 = 1139;
-    pub const COMP_4_0_GAIN: u16 = 1140;
-    pub const COMP_4_0_RATIO: u16 = 1141;
-    pub const COMP_4_0_KNEE: u16 = 1142;
-    pub const COMP_4_0_ATIME: u16 = 1143;
-    pub const COMP_4_0_RTIME: u16 = 1144;
-    pub const DELAY_4_0: u16 = 1145;
+    pub const POLARITY_OUT_11_0: u16 = 1045;
+    pub const PEQ_11_1: u16 = 1046;
+    pub const PEQ_11_2: u16 = 1051;
+    pub const PEQ_11_3: u16 = 1056;
+    pub const PEQ_11_4: u16 = 1061;
+    pub const PEQ_11_5: u16 = 1066;
+    pub const PEQ_11_6: u16 = 1071;
+    pub const PEQ_11_7: u16 = 1076;
+    pub const PEQ_11_8: u16 = 1081;
+    pub const PEQ_11_9: u16 = 1086;
+    pub const PEQ_11_10: u16 = 1091;
+    pub const BPF_11_1: u16 = 1096;
+    pub const BPF_11_5: u16 = 1116;
+    pub const D_GAIN_12_0_STATUS: u16 = 1136;
+    pub const COMP_12_0_STATUS: u16 = 1137;
+    pub const D_GAIN_12_0: u16 = 1138;
+    pub const COMP_12_0_THRESHOLD: u16 = 1139;
+    pub const COMP_12_0_GAIN: u16 = 1140;
+    pub const COMP_12_0_RATIO: u16 = 1141;
+    pub const COMP_12_0_KNEE: u16 = 1142;
+    pub const COMP_12_0_ATIME: u16 = 1143;
+    pub const COMP_12_0_RTIME: u16 = 1144;
+    pub const DELAY_12_0: u16 = 1145;
     pub const METER_4_0: u16 = 1146;
     pub const METER_4_1: u16 = 1147;
     pub const METER_4_2: u16 = 1148;
-    pub const POLARITY_OUT_4_0: u16 = 1149;
-    pub const PEQ_4_1: u16 = 1150;
-    pub const PEQ_4_2: u16 = 1155;
-    pub const PEQ_4_3: u16 = 1160;
-    pub const PEQ_4_4: u16 = 1165;
-    pub const PEQ_4_5: u16 = 1170;
-    pub const PEQ_4_6: u16 = 1175;
-    pub const PEQ_4_7: u16 = 1180;
-    pub const PEQ_4_8: u16 = 1185;
-    pub const PEQ_4_9: u16 = 1190;
-    pub const PEQ_4_10: u16 = 1195;
-    pub const BPF_4_1: u16 = 1200;
-    pub const BPF_4_5: u16 = 1220;
-    pub const D_GAIN_5_0_STATUS: u16 = 1240;
-    pub const COMP_5_0_STATUS: u16 = 1241;
-    pub const D_GAIN_5_0: u16 = 1242;
-    pub const COMP_5_0_THRESHOLD: u16 = 1243;
-    pub const COMP_5_0_GAIN: u16 = 1244;
-    pub const COMP_5_0_RATIO: u16 = 1245;
-    pub const COMP_5_0_KNEE: u16 = 1246;
-    pub const COMP_5_0_ATIME: u16 = 1247;
-    pub const COMP_5_0_RTIME: u16 = 1248;
-    pub const DELAY_5_0: u16 = 1249;
+    pub const POLARITY_OUT_12_0: u16 = 1149;
+    pub const PEQ_12_1: u16 = 1150;
+    pub const PEQ_12_2: u16 = 1155;
+    pub const PEQ_12_3: u16 = 1160;
+    pub const PEQ_12_4: u16 = 1165;
+    pub const PEQ_12_5: u16 = 1170;
+    pub const PEQ_12_6: u16 = 1175;
+    pub const PEQ_12_7: u16 = 1180;
+    pub const PEQ_12_8: u16 = 1185;
+    pub const PEQ_12_9: u16 = 1190;
+    pub const PEQ_12_10: u16 = 1195;
+    pub const BPF_12_1: u16 = 1200;
+    pub const BPF_12_5: u16 = 1220;
+    pub const D_GAIN_13_0_STATUS: u16 = 1240;
+    pub const COMP_13_0_STATUS: u16 = 1241;
+    pub const D_GAIN_13_0: u16 = 1242;
+    pub const COMP_13_0_THRESHOLD: u16 = 1243;
+    pub const COMP_13_0_GAIN: u16 = 1244;
+    pub const COMP_13_0_RATIO: u16 = 1245;
+    pub const COMP_13_0_KNEE: u16 = 1246;
+    pub const COMP_13_0_ATIME: u16 = 1247;
+    pub const COMP_13_0_RTIME: u16 = 1248;
+    pub const DELAY_13_0: u16 = 1249;
     pub const METER_5_0: u16 = 1250;
     pub const METER_5_1: u16 = 1251;
     pub const METER_5_2: u16 = 1252;
-    pub const POLARITY_OUT_5_0: u16 = 1253;
-    pub const PEQ_5_1: u16 = 1254;
-    pub const PEQ_5_2: u16 = 1259;
-    pub const PEQ_5_3: u16 = 1264;
-    pub const PEQ_5_4: u16 = 1269;
-    pub const PEQ_5_5: u16 = 1274;
-    pub const PEQ_5_6: u16 = 1279;
-    pub const PEQ_5_7: u16 = 1284;
-    pub const PEQ_5_8: u16 = 1289;
-    pub const PEQ_5_9: u16 = 1294;
-    pub const PEQ_5_10: u16 = 1299;
-    pub const BPF_5_1: u16 = 1304;
-    pub const BPF_5_5: u16 = 1324;
-    pub const D_GAIN_6_0_STATUS: u16 = 1344;
-    pub const COMP_6_0_STATUS: u16 = 1345;
-    pub const D_GAIN_6_0: u16 = 1346;
-    pub const COMP_6_0_THRESHOLD: u16 = 1347;
-    pub const COMP_6_0_GAIN: u16 = 1348;
-    pub const COMP_6_0_RATIO: u16 = 1349;
-    pub const COMP_6_0_KNEE: u16 = 1350;
-    pub const COMP_6_0_ATIME: u16 = 1351;
-    pub const COMP_6_0_RTIME: u16 = 1352;
-    pub const DELAY_6_0: u16 = 1353;
+    pub const POLARITY_OUT_13_0: u16 = 1253;
+    pub const PEQ_13_1: u16 = 1254;
+    pub const PEQ_13_2: u16 = 1259;
+    pub const PEQ_13_3: u16 = 1264;
+    pub const PEQ_13_4: u16 = 1269;
+    pub const PEQ_13_5: u16 = 1274;
+    pub const PEQ_13_6: u16 = 1279;
+    pub const PEQ_13_7: u16 = 1284;
+    pub const PEQ_13_8: u16 = 1289;
+    pub const PEQ_13_9: u16 = 1294;
+    pub const PEQ_13_10: u16 = 1299;
+    pub const BPF_13_1: u16 = 1304;
+    pub const BPF_13_5: u16 = 1324;
+    pub const D_GAIN_14_0_STATUS: u16 = 1344;
+    pub const COMP_14_0_STATUS: u16 = 1345;
+    pub const D_GAIN_14_0: u16 = 1346;
+    pub const COMP_14_0_THRESHOLD: u16 = 1347;
+    pub const COMP_14_0_GAIN: u16 = 1348;
+    pub const COMP_14_0_RATIO: u16 = 1349;
+    pub const COMP_14_0_KNEE: u16 = 1350;
+    pub const COMP_14_0_ATIME: u16 = 1351;
+    pub const COMP_14_0_RTIME: u16 = 1352;
+    pub const DELAY_14_0: u16 = 1353;
     pub const METER_6_0: u16 = 1354;
     pub const METER_6_1: u16 = 1355;
     pub const METER_6_2: u16 = 1356;
-    pub const POLARITY_OUT_6_0: u16 = 1357;
-    pub const PEQ_6_1: u16 = 1358;
-    pub const PEQ_6_2: u16 = 1363;
-    pub const PEQ_6_3: u16 = 1368;
-    pub const PEQ_6_4: u16 = 1373;
-    pub const PEQ_6_5: u16 = 1378;
-    pub const PEQ_6_6: u16 = 1383;
-    pub const PEQ_6_7: u16 = 1388;
-    pub const PEQ_6_8: u16 = 1393;
-    pub const PEQ_6_9: u16 = 1398;
-    pub const PEQ_6_10: u16 = 1403;
-    pub const BPF_6_1: u16 = 1408;
-    pub const BPF_6_5: u16 = 1428;
-    pub const D_GAIN_7_0_STATUS: u16 = 1448;
-    pub const COMP_7_0_STATUS: u16 = 1449;
-    pub const D_GAIN_7_0: u16 = 1450;
-    pub const COMP_7_0_THRESHOLD: u16 = 1451;
-    pub const COMP_7_0_GAIN: u16 = 1452;
-    pub const COMP_7_0_RATIO: u16 = 1453;
-    pub const COMP_7_0_KNEE: u16 = 1454;
-    pub const COMP_7_0_ATIME: u16 = 1455;
-    pub const COMP_7_0_RTIME: u16 = 1456;
-    pub const DELAY_7_0: u16 = 1457;
+    pub const POLARITY_OUT_14_0: u16 = 1357;
+    pub const PEQ_14_1: u16 = 1358;
+    pub const PEQ_14_2: u16 = 1363;
+    pub const PEQ_14_3: u16 = 1368;
+    pub const PEQ_14_4: u16 = 1373;
+    pub const PEQ_14_5: u16 = 1378;
+    pub const PEQ_14_6: u16 = 1383;
+    pub const PEQ_14_7: u16 = 1388;
+    pub const PEQ_14_8: u16 = 1393;
+    pub const PEQ_14_9: u16 = 1398;
+    pub const PEQ_14_10: u16 = 1403;
+    pub const BPF_14_1: u16 = 1408;
+    pub const BPF_14_5: u16 = 1428;
+    pub const D_GAIN_15_0_STATUS: u16 = 1448;
+    pub const COMP_15_0_STATUS: u16 = 1449;
+    pub const D_GAIN_15_0: u16 = 1450;
+    pub const COMP_15_0_THRESHOLD: u16 = 1451;
+    pub const COMP_15_0_GAIN: u16 = 1452;
+    pub const COMP_15_0_RATIO: u16 = 1453;
+    pub const COMP_15_0_KNEE: u16 = 1454;
+    pub const COMP_15_0_ATIME: u16 = 1455;
+    pub const COMP_15_0_RTIME: u16 = 1456;
+    pub const DELAY_15_0: u16 = 1457;
     pub const METER_7_0: u16 = 1458;
     pub const METER_7_1: u16 = 1459;
     pub const METER_7_2: u16 = 1460;
-    pub const POLARITY_OUT_7_0: u16 = 1461;
-    pub const PEQ_7_1: u16 = 1462;
-    pub const PEQ_7_2: u16 = 1467;
-    pub const PEQ_7_3: u16 = 1472;
-    pub const PEQ_7_4: u16 = 1477;
-    pub const PEQ_7_5: u16 = 1482;
-    pub const PEQ_7_6: u16 = 1487;
-    pub const PEQ_7_7: u16 = 1492;
-    pub const PEQ_7_8: u16 = 1497;
-    pub const PEQ_7_9: u16 = 1502;
-    pub const PEQ_7_10: u16 = 1507;
-    pub const BPF_7_1: u16 = 1512;
-    pub const BPF_7_5: u16 = 1532;
-    pub const D_GAIN_8_0_STATUS: u16 = 1552;
-    pub const COMP_8_0_STATUS: u16 = 1553;
-    pub const D_GAIN_8_0: u16 = 1554;
-    pub const COMP_8_0_THRESHOLD: u16 = 1555;
-    pub const COMP_8_0_GAIN: u16 = 1556;
-    pub const COMP_8_0_RATIO: u16 = 1557;
-    pub const COMP_8_0_KNEE: u16 = 1558;
-    pub const COMP_8_0_ATIME: u16 = 1559;
-    pub const COMP_8_0_RTIME: u16 = 1560;
-    pub const DELAY_8_0: u16 = 1561;
+    pub const POLARITY_OUT_15_0: u16 = 1461;
+    pub const PEQ_15_1: u16 = 1462;
+    pub const PEQ_15_2: u16 = 1467;
+    pub const PEQ_15_3: u16 = 1472;
+    pub const PEQ_15_4: u16 = 1477;
+    pub const PEQ_15_5: u16 = 1482;
+    pub const PEQ_15_6: u16 = 1487;
+    pub const PEQ_15_7: u16 = 1492;
+    pub const PEQ_15_8: u16 = 1497;
+    pub const PEQ_15_9: u16 = 1502;
+    pub const PEQ_15_10: u16 = 1507;
+    pub const BPF_15_1: u16 = 1512;
+    pub const BPF_15_5: u16 = 1532;
+    pub const D_GAIN_16_0_STATUS: u16 = 1552;
+    pub const COMP_16_0_STATUS: u16 = 1553;
+    pub const D_GAIN_16_0: u16 = 1554;
+    pub const COMP_16_0_THRESHOLD: u16 = 1555;
+    pub const COMP_16_0_GAIN: u16 = 1556;
+    pub const COMP_16_0_RATIO: u16 = 1557;
+    pub const COMP_16_0_KNEE: u16 = 1558;
+    pub const COMP_16_0_ATIME: u16 = 1559;
+    pub const COMP_16_0_RTIME: u16 = 1560;
+    pub const DELAY_16_0: u16 = 1561;
     pub const METER_8_0: u16 = 1562;
     pub const METER_8_1: u16 = 1563;
     pub const METER_8_2: u16 = 1564;
-    pub const POLARITY_OUT_8_0: u16 = 1565;
-    pub const PEQ_8_1: u16 = 1566;
-    pub const PEQ_8_2: u16 = 1571;
-    pub const PEQ_8_3: u16 = 1576;
-    pub const PEQ_8_4: u16 = 1581;
-    pub const PEQ_8_5: u16 = 1586;
-    pub const PEQ_8_6: u16 = 1591;
-    pub const PEQ_8_7: u16 = 1596;
-    pub const PEQ_8_8: u16 = 1601;
-    pub const PEQ_8_9: u16 = 1606;
-    pub const PEQ_8_10: u16 = 1611;
-    pub const BPF_8_1: u16 = 1616;
-    pub const BPF_8_5: u16 = 1636;
+    pub const POLARITY_OUT_16_0: u16 = 1565;
+    pub const PEQ_16_1: u16 = 1566;
+    pub const PEQ_16_2: u16 = 1571;
+    pub const PEQ_16_3: u16 = 1576;
+    pub const PEQ_16_4: u16 = 1581;
+    pub const PEQ_16_5: u16 = 1586;
+    pub const PEQ_16_6: u16 = 1591;
+    pub const PEQ_16_7: u16 = 1596;
+    pub const PEQ_16_8: u16 = 1601;
+    pub const PEQ_16_9: u16 = 1606;
+    pub const PEQ_16_10: u16 = 1611;
+    pub const BPF_16_1: u16 = 1616;
+    pub const BPF_16_5: u16 = 1636;
+    pub const PEQ_1_1: u16 = 1656;
+    pub const PEQ_1_2: u16 = 1661;
+    pub const PEQ_1_3: u16 = 1666;
+    pub const PEQ_1_4: u16 = 1671;
+    pub const PEQ_1_5: u16 = 1676;
+    pub const PEQ_1_6: u16 = 1681;
+    pub const PEQ_1_7: u16 = 1686;
+    pub const PEQ_1_8: u16 = 1691;
+    pub const PEQ_1_9: u16 = 1696;
+    pub const PEQ_1_10: u16 = 1701;
+    pub const PEQ_2_1: u16 = 1706;
+    pub const PEQ_2_2: u16 = 1711;
+    pub const PEQ_2_3: u16 = 1716;
+    pub const PEQ_2_4: u16 = 1721;
+    pub const PEQ_2_5: u16 = 1726;
+    pub const PEQ_2_6: u16 = 1731;
+    pub const PEQ_2_7: u16 = 1736;
+    pub const PEQ_2_8: u16 = 1741;
+    pub const PEQ_2_9: u16 = 1746;
+    pub const PEQ_2_10: u16 = 1751;
+    pub const PEQ_3_1: u16 = 1756;
+    pub const PEQ_3_2: u16 = 1761;
+    pub const PEQ_3_3: u16 = 1766;
+    pub const PEQ_3_4: u16 = 1771;
+    pub const PEQ_3_5: u16 = 1776;
+    pub const PEQ_3_6: u16 = 1781;
+    pub const PEQ_3_7: u16 = 1786;
+    pub const PEQ_3_8: u16 = 1791;
+    pub const PEQ_3_9: u16 = 1796;
+    pub const PEQ_3_10: u16 = 1801;
+    pub const PEQ_4_1: u16 = 1806;
+    pub const PEQ_4_2: u16 = 1811;
+    pub const PEQ_4_3: u16 = 1816;
+    pub const PEQ_4_4: u16 = 1821;
+    pub const PEQ_4_5: u16 = 1826;
+    pub const PEQ_4_6: u16 = 1831;
+    pub const PEQ_4_7: u16 = 1836;
+    pub const PEQ_4_8: u16 = 1841;
+    pub const PEQ_4_9: u16 = 1846;
+    pub const PEQ_4_10: u16 = 1851;
+    pub const PEQ_5_1: u16 = 1856;
+    pub const PEQ_5_2: u16 = 1861;
+    pub const PEQ_5_3: u16 = 1866;
+    pub const PEQ_5_4: u16 = 1871;
+    pub const PEQ_5_5: u16 = 1876;
+    pub const PEQ_5_6: u16 = 1881;
+    pub const PEQ_5_7: u16 = 1886;
+    pub const PEQ_5_8: u16 = 1891;
+    pub const PEQ_5_9: u16 = 1896;
+    pub const PEQ_5_10: u16 = 1901;
+    pub const PEQ_6_1: u16 = 1906;
+    pub const PEQ_6_2: u16 = 1911;
+    pub const PEQ_6_3: u16 = 1916;
+    pub const PEQ_6_4: u16 = 1921;
+    pub const PEQ_6_5: u16 = 1926;
+    pub const PEQ_6_6: u16 = 1931;
+    pub const PEQ_6_7: u16 = 1936;
+    pub const PEQ_6_8: u16 = 1941;
+    pub const PEQ_6_9: u16 = 1946;
+    pub const PEQ_6_10: u16 = 1951;
+    pub const PEQ_7_1: u16 = 1956;
+    pub const PEQ_7_2: u16 = 1961;
+    pub const PEQ_7_3: u16 = 1966;
+    pub const PEQ_7_4: u16 = 1971;
+    pub const PEQ_7_5: u16 = 1976;
+    pub const PEQ_7_6: u16 = 1981;
+    pub const PEQ_7_7: u16 = 1986;
+    pub const PEQ_7_8: u16 = 1991;
+    pub const PEQ_7_9: u16 = 1996;
+    pub const PEQ_7_10: u16 = 2001;
+    pub const PEQ_8_1: u16 = 2006;
+    pub const PEQ_8_2: u16 = 2011;
+    pub const PEQ_8_3: u16 = 2016;
+    pub const PEQ_8_4: u16 = 2021;
+    pub const PEQ_8_5: u16 = 2026;
+    pub const PEQ_8_6: u16 = 2031;
+    pub const PEQ_8_7: u16 = 2036;
+    pub const PEQ_8_8: u16 = 2041;
+    pub const PEQ_8_9: u16 = 2046;
+    pub const PEQ_8_10: u16 = 2051;
     #[cfg(feature = "symbols")]
     pub const SYMBOLS: &[(&str, u16)] = &[
         ("BM_BPF_ALL_1", BM_BPF_ALL_1),
@@ -1162,36 +1242,230 @@ pub mod sym {
         ("METER_D_OUT_6", METER_D_OUT_6),
         ("METER_D_OUT_7", METER_D_OUT_7),
         ("METER_D_OUT_8", METER_D_OUT_8),
-        ("METER_COMP_1", METER_COMP_1),
-        ("METER_COMP_2", METER_COMP_2),
-        ("METER_COMP_3", METER_COMP_3),
-        ("METER_COMP_4", METER_COMP_4),
-        ("METER_COMP_5", METER_COMP_5),
-        ("METER_COMP_6", METER_COMP_6),
-        ("METER_COMP_7", METER_COMP_7),
-        ("METER_COMP_8", METER_COMP_8),
-        ("METER_OUT_1", METER_OUT_1),
-        ("METER_OUT_2", METER_OUT_2),
-        ("METER_OUT_3", METER_OUT_3),
-        ("METER_OUT_4", METER_OUT_4),
-        ("METER_OUT_5", METER_OUT_5),
-        ("METER_OUT_6", METER_OUT_6),
-        ("METER_OUT_7", METER_OUT_7),
-        ("METER_OUT_8", METER_OUT_8),
-        ("D_GAIN_1_0_STATUS", D_GAIN_1_0_STATUS),
-        ("COMP_1_0_STATUS", COMP_1_0_STATUS),
-        ("D_GAIN_1_0", D_GAIN_1_0),
-        ("COMP_1_0_THRESHOLD", COMP_1_0_THRESHOLD),
-        ("COMP_1_0_GAIN", COMP_1_0_GAIN),
-        ("COMP_1_0_RATIO", COMP_1_0_RATIO),
-        ("COMP_1_0_KNEE", COMP_1_0_KNEE),
-        ("COMP_1_0_ATIME", COMP_1_0_ATIME),
-        ("COMP_1_0_RTIME", COMP_1_0_RTIME),
-        ("DELAY_1_0", DELAY_1_0),
+        ("METER_COMP_9", METER_COMP_9),
+        ("METER_COMP_10", METER_COMP_10),
+        ("METER_COMP_11", METER_COMP_11),
+        ("METER_COMP_12", METER_COMP_12),
+        ("METER_COMP_13", METER_COMP_13),
+        ("METER_COMP_14", METER_COMP_14),
+        ("METER_COMP_15", METER_COMP_15),
+        ("METER_COMP_16", METER_COMP_16),
+        ("METER_OUT_9", METER_OUT_9),
+        ("METER_OUT_10", METER_OUT_10),
+        ("METER_OUT_11", METER_OUT_11),
+        ("METER_OUT_12", METER_OUT_12),
+        ("METER_OUT_13", METER_OUT_13),
+        ("METER_OUT_14", METER_OUT_14),
+        ("METER_OUT_15", METER_OUT_15),
+        ("METER_OUT_16", METER_OUT_16),
+        ("D_GAIN_9_0_STATUS", D_GAIN_9_0_STATUS),
+        ("COMP_9_0_STATUS", COMP_9_0_STATUS),
+        ("D_GAIN_9_0", D_GAIN_9_0),
+        ("COMP_9_0_THRESHOLD", COMP_9_0_THRESHOLD),
+        ("COMP_9_0_GAIN", COMP_9_0_GAIN),
+        ("COMP_9_0_RATIO", COMP_9_0_RATIO),
+        ("COMP_9_0_KNEE", COMP_9_0_KNEE),
+        ("COMP_9_0_ATIME", COMP_9_0_ATIME),
+        ("COMP_9_0_RTIME", COMP_9_0_RTIME),
+        ("DELAY_9_0", DELAY_9_0),
         ("METER_1_0", METER_1_0),
         ("METER_1_1", METER_1_1),
         ("METER_1_2", METER_1_2),
-        ("POLARITY_OUT_1_0", POLARITY_OUT_1_0),
+        ("POLARITY_OUT_9_0", POLARITY_OUT_9_0),
+        ("PEQ_9_1", PEQ_9_1),
+        ("PEQ_9_2", PEQ_9_2),
+        ("PEQ_9_3", PEQ_9_3),
+        ("PEQ_9_4", PEQ_9_4),
+        ("PEQ_9_5", PEQ_9_5),
+        ("PEQ_9_6", PEQ_9_6),
+        ("PEQ_9_7", PEQ_9_7),
+        ("PEQ_9_8", PEQ_9_8),
+        ("PEQ_9_9", PEQ_9_9),
+        ("PEQ_9_10", PEQ_9_10),
+        ("BPF_9_1", BPF_9_1),
+        ("BPF_9_5", BPF_9_5),
+        ("D_GAIN_10_0_STATUS", D_GAIN_10_0_STATUS),
+        ("COMP_10_0_STATUS", COMP_10_0_STATUS),
+        ("D_GAIN_10_0", D_GAIN_10_0),
+        ("COMP_10_0_THRESHOLD", COMP_10_0_THRESHOLD),
+        ("COMP_10_0_GAIN", COMP_10_0_GAIN),
+        ("COMP_10_0_RATIO", COMP_10_0_RATIO),
+        ("COMP_10_0_KNEE", COMP_10_0_KNEE),
+        ("COMP_10_0_ATIME", COMP_10_0_ATIME),
+        ("COMP_10_0_RTIME", COMP_10_0_RTIME),
+        ("DELAY_10_0", DELAY_10_0),
+        ("METER_2_0", METER_2_0),
+        ("METER_2_1", METER_2_1),
+        ("METER_2_2", METER_2_2),
+        ("POLARITY_OUT_10_0", POLARITY_OUT_10_0),
+        ("PEQ_10_1", PEQ_10_1),
+        ("PEQ_10_2", PEQ_10_2),
+        ("PEQ_10_3", PEQ_10_3),
+        ("PEQ_10_4", PEQ_10_4),
+        ("PEQ_10_5", PEQ_10_5),
+        ("PEQ_10_6", PEQ_10_6),
+        ("PEQ_10_7", PEQ_10_7),
+        ("PEQ_10_8", PEQ_10_8),
+        ("PEQ_10_9", PEQ_10_9),
+        ("PEQ_10_10", PEQ_10_10),
+        ("BPF_10_1", BPF_10_1),
+        ("BPF_10_5", BPF_10_5),
+        ("D_GAIN_11_0_STATUS", D_GAIN_11_0_STATUS),
+        ("COMP_11_0_STATUS", COMP_11_0_STATUS),
+        ("D_GAIN_11_0", D_GAIN_11_0),
+        ("COMP_11_0_THRESHOLD", COMP_11_0_THRESHOLD),
+        ("COMP_11_0_GAIN", COMP_11_0_GAIN),
+        ("COMP_11_0_RATIO", COMP_11_0_RATIO),
+        ("COMP_11_0_KNEE", COMP_11_0_KNEE),
+        ("COMP_11_0_ATIME", COMP_11_0_ATIME),
+        ("COMP_11_0_RTIME", COMP_11_0_RTIME),
+        ("DELAY_11_0", DELAY_11_0),
+        ("METER_3_0", METER_3_0),
+        ("METER_3_1", METER_3_1),
+        ("METER_3_2", METER_3_2),
+        ("POLARITY_OUT_11_0", POLARITY_OUT_11_0),
+        ("PEQ_11_1", PEQ_11_1),
+        ("PEQ_11_2", PEQ_11_2),
+        ("PEQ_11_3", PEQ_11_3),
+        ("PEQ_11_4", PEQ_11_4),
+        ("PEQ_11_5", PEQ_11_5),
+        ("PEQ_11_6", PEQ_11_6),
+        ("PEQ_11_7", PEQ_11_7),
+        ("PEQ_11_8", PEQ_11_8),
+        ("PEQ_11_9", PEQ_11_9),
+        ("PEQ_11_10", PEQ_11_10),
+        ("BPF_11_1", BPF_11_1),
+        ("BPF_11_5", BPF_11_5),
+        ("D_GAIN_12_0_STATUS", D_GAIN_12_0_STATUS),
+        ("COMP_12_0_STATUS", COMP_12_0_STATUS),
+        ("D_GAIN_12_0", D_GAIN_12_0),
+        ("COMP_12_0_THRESHOLD", COMP_12_0_THRESHOLD),
+        ("COMP_12_0_GAIN", COMP_12_0_GAIN),
+        ("COMP_12_0_RATIO", COMP_12_0_RATIO),
+        ("COMP_12_0_KNEE", COMP_12_0_KNEE),
+        ("COMP_12_0_ATIME", COMP_12_0_ATIME),
+        ("COMP_12_0_RTIME", COMP_12_0_RTIME),
+        ("DELAY_12_0", DELAY_12_0),
+        ("METER_4_0", METER_4_0),
+        ("METER_4_1", METER_4_1),
+        ("METER_4_2", METER_4_2),
+        ("POLARITY_OUT_12_0", POLARITY_OUT_12_0),
+        ("PEQ_12_1", PEQ_12_1),
+        ("PEQ_12_2", PEQ_12_2),
+        ("PEQ_12_3", PEQ_12_3),
+        ("PEQ_12_4", PEQ_12_4),
+        ("PEQ_12_5", PEQ_12_5),
+        ("PEQ_12_6", PEQ_12_6),
+        ("PEQ_12_7", PEQ_12_7),
+        ("PEQ_12_8", PEQ_12_8),
+        ("PEQ_12_9", PEQ_12_9),
+        ("PEQ_12_10", PEQ_12_10),
+        ("BPF_12_1", BPF_12_1),
+        ("BPF_12_5", BPF_12_5),
+        ("D_GAIN_13_0_STATUS", D_GAIN_13_0_STATUS),
+        ("COMP_13_0_STATUS", COMP_13_0_STATUS),
+        ("D_GAIN_13_0", D_GAIN_13_0),
+        ("COMP_13_0_THRESHOLD", COMP_13_0_THRESHOLD),
+        ("COMP_13_0_GAIN", COMP_13_0_GAIN),
+        ("COMP_13_0_RATIO", COMP_13_0_RATIO),
+        ("COMP_13_0_KNEE", COMP_13_0_KNEE),
+        ("COMP_13_0_ATIME", COMP_13_0_ATIME),
+        ("COMP_13_0_RTIME", COMP_13_0_RTIME),
+        ("DELAY_13_0", DELAY_13_0),
+        ("METER_5_0", METER_5_0),
+        ("METER_5_1", METER_5_1),
+        ("METER_5_2", METER_5_2),
+        ("POLARITY_OUT_13_0", POLARITY_OUT_13_0),
+        ("PEQ_13_1", PEQ_13_1),
+        ("PEQ_13_2", PEQ_13_2),
+        ("PEQ_13_3", PEQ_13_3),
+        ("PEQ_13_4", PEQ_13_4),
+        ("PEQ_13_5", PEQ_13_5),
+        ("PEQ_13_6", PEQ_13_6),
+        ("PEQ_13_7", PEQ_13_7),
+        ("PEQ_13_8", PEQ_13_8),
+        ("PEQ_13_9", PEQ_13_9),
+        ("PEQ_13_10", PEQ_13_10),
+        ("BPF_13_1", BPF_13_1),
+        ("BPF_13_5", BPF_13_5),
+        ("D_GAIN_14_0_STATUS", D_GAIN_14_0_STATUS),
+        ("COMP_14_0_STATUS", COMP_14_0_STATUS),
+        ("D_GAIN_14_0", D_GAIN_14_0),
+        ("COMP_14_0_THRESHOLD", COMP_14_0_THRESHOLD),
+        ("COMP_14_0_GAIN", COMP_14_0_GAIN),
+        ("COMP_14_0_RATIO", COMP_14_0_RATIO),
+        ("COMP_14_0_KNEE", COMP_14_0_KNEE),
+        ("COMP_14_0_ATIME", COMP_14_0_ATIME),
+        ("COMP_14_0_RTIME", COMP_14_0_RTIME),
+        ("DELAY_14_0", DELAY_14_0),
+        ("METER_6_0", METER_6_0),
+        ("METER_6_1", METER_6_1),
+        ("METER_6_2", METER_6_2),
+        ("POLARITY_OUT_14_0", POLARITY_OUT_14_0),
+        ("PEQ_14_1", PEQ_14_1),
+        ("PEQ_14_2", PEQ_14_2),
+        ("PEQ_14_3", PEQ_14_3),
+        ("PEQ_14_4", PEQ_14_4),
+        ("PEQ_14_5", PEQ_14_5),
+        ("PEQ_14_6", PEQ_14_6),
+        ("PEQ_14_7", PEQ_14_7),
+        ("PEQ_14_8", PEQ_14_8),
+        ("PEQ_14_9", PEQ_14_9),
+        ("PEQ_14_10", PEQ_14_10),
+        ("BPF_14_1", BPF_14_1),
+        ("BPF_14_5", BPF_14_5),
+        ("D_GAIN_15_0_STATUS", D_GAIN_15_0_STATUS),
+        ("COMP_15_0_STATUS", COMP_15_0_STATUS),
+        ("D_GAIN_15_0", D_GAIN_15_0),
+        ("COMP_15_0_THRESHOLD", COMP_15_0_THRESHOLD),
+        ("COMP_15_0_GAIN", COMP_15_0_GAIN),
+        ("COMP_15_0_RATIO", COMP_15_0_RATIO),
+        ("COMP_15_0_KNEE", COMP_15_0_KNEE),
+        ("COMP_15_0_ATIME", COMP_15_0_ATIME),
+        ("COMP_15_0_RTIME", COMP_15_0_RTIME),
+        ("DELAY_15_0", DELAY_15_0),
+        ("METER_7_0", METER_7_0),
+        ("METER_7_1", METER_7_1),
+        ("METER_7_2", METER_7_2),
+        ("POLARITY_OUT_15_0", POLARITY_OUT_15_0),
+        ("PEQ_15_1", PEQ_15_1),
+        ("PEQ_15_2", PEQ_15_2),
+        ("PEQ_15_3", PEQ_15_3),
+        ("PEQ_15_4", PEQ_15_4),
+        ("PEQ_15_5", PEQ_15_5),
+        ("PEQ_15_6", PEQ_15_6),
+        ("PEQ_15_7", PEQ_15_7),
+        ("PEQ_15_8", PEQ_15_8),
+        ("PEQ_15_9", PEQ_15_9),
+        ("PEQ_15_10", PEQ_15_10),
+        ("BPF_15_1", BPF_15_1),
+        ("BPF_15_5", BPF_15_5),
+        ("D_GAIN_16_0_STATUS", D_GAIN_16_0_STATUS),
+        ("COMP_16_0_STATUS", COMP_16_0_STATUS),
+        ("D_GAIN_16_0", D_GAIN_16_0),
+        ("COMP_16_0_THRESHOLD", COMP_16_0_THRESHOLD),
+        ("COMP_16_0_GAIN", COMP_16_0_GAIN),
+        ("COMP_16_0_RATIO", COMP_16_0_RATIO),
+        ("COMP_16_0_KNEE", COMP_16_0_KNEE),
+        ("COMP_16_0_ATIME", COMP_16_0_ATIME),
+        ("COMP_16_0_RTIME", COMP_16_0_RTIME),
+        ("DELAY_16_0", DELAY_16_0),
+        ("METER_8_0", METER_8_0),
+        ("METER_8_1", METER_8_1),
+        ("METER_8_2", METER_8_2),
+        ("POLARITY_OUT_16_0", POLARITY_OUT_16_0),
+        ("PEQ_16_1", PEQ_16_1),
+        ("PEQ_16_2", PEQ_16_2),
+        ("PEQ_16_3", PEQ_16_3),
+        ("PEQ_16_4", PEQ_16_4),
+        ("PEQ_16_5", PEQ_16_5),
+        ("PEQ_16_6", PEQ_16_6),
+        ("PEQ_16_7", PEQ_16_7),
+        ("PEQ_16_8", PEQ_16_8),
+        ("PEQ_16_9", PEQ_16_9),
+        ("PEQ_16_10", PEQ_16_10),
+        ("BPF_16_1", BPF_16_1),
+        ("BPF_16_5", BPF_16_5),
         ("PEQ_1_1", PEQ_1_1),
         ("PEQ_1_2", PEQ_1_2),
         ("PEQ_1_3", PEQ_1_3),
@@ -1202,22 +1476,6 @@ pub mod sym {
         ("PEQ_1_8", PEQ_1_8),
         ("PEQ_1_9", PEQ_1_9),
         ("PEQ_1_10", PEQ_1_10),
-        ("BPF_1_1", BPF_1_1),
-        ("BPF_1_5", BPF_1_5),
-        ("D_GAIN_2_0_STATUS", D_GAIN_2_0_STATUS),
-        ("COMP_2_0_STATUS", COMP_2_0_STATUS),
-        ("D_GAIN_2_0", D_GAIN_2_0),
-        ("COMP_2_0_THRESHOLD", COMP_2_0_THRESHOLD),
-        ("COMP_2_0_GAIN", COMP_2_0_GAIN),
-        ("COMP_2_0_RATIO", COMP_2_0_RATIO),
-        ("COMP_2_0_KNEE", COMP_2_0_KNEE),
-        ("COMP_2_0_ATIME", COMP_2_0_ATIME),
-        ("COMP_2_0_RTIME", COMP_2_0_RTIME),
-        ("DELAY_2_0", DELAY_2_0),
-        ("METER_2_0", METER_2_0),
-        ("METER_2_1", METER_2_1),
-        ("METER_2_2", METER_2_2),
-        ("POLARITY_OUT_2_0", POLARITY_OUT_2_0),
         ("PEQ_2_1", PEQ_2_1),
         ("PEQ_2_2", PEQ_2_2),
         ("PEQ_2_3", PEQ_2_3),
@@ -1228,22 +1486,6 @@ pub mod sym {
         ("PEQ_2_8", PEQ_2_8),
         ("PEQ_2_9", PEQ_2_9),
         ("PEQ_2_10", PEQ_2_10),
-        ("BPF_2_1", BPF_2_1),
-        ("BPF_2_5", BPF_2_5),
-        ("D_GAIN_3_0_STATUS", D_GAIN_3_0_STATUS),
-        ("COMP_3_0_STATUS", COMP_3_0_STATUS),
-        ("D_GAIN_3_0", D_GAIN_3_0),
-        ("COMP_3_0_THRESHOLD", COMP_3_0_THRESHOLD),
-        ("COMP_3_0_GAIN", COMP_3_0_GAIN),
-        ("COMP_3_0_RATIO", COMP_3_0_RATIO),
-        ("COMP_3_0_KNEE", COMP_3_0_KNEE),
-        ("COMP_3_0_ATIME", COMP_3_0_ATIME),
-        ("COMP_3_0_RTIME", COMP_3_0_RTIME),
-        ("DELAY_3_0", DELAY_3_0),
-        ("METER_3_0", METER_3_0),
-        ("METER_3_1", METER_3_1),
-        ("METER_3_2", METER_3_2),
-        ("POLARITY_OUT_3_0", POLARITY_OUT_3_0),
         ("PEQ_3_1", PEQ_3_1),
         ("PEQ_3_2", PEQ_3_2),
         ("PEQ_3_3", PEQ_3_3),
@@ -1254,22 +1496,6 @@ pub mod sym {
         ("PEQ_3_8", PEQ_3_8),
         ("PEQ_3_9", PEQ_3_9),
         ("PEQ_3_10", PEQ_3_10),
-        ("BPF_3_1", BPF_3_1),
-        ("BPF_3_5", BPF_3_5),
-        ("D_GAIN_4_0_STATUS", D_GAIN_4_0_STATUS),
-        ("COMP_4_0_STATUS", COMP_4_0_STATUS),
-        ("D_GAIN_4_0", D_GAIN_4_0),
-        ("COMP_4_0_THRESHOLD", COMP_4_0_THRESHOLD),
-        ("COMP_4_0_GAIN", COMP_4_0_GAIN),
-        ("COMP_4_0_RATIO", COMP_4_0_RATIO),
-        ("COMP_4_0_KNEE", COMP_4_0_KNEE),
-        ("COMP_4_0_ATIME", COMP_4_0_ATIME),
-        ("COMP_4_0_RTIME", COMP_4_0_RTIME),
-        ("DELAY_4_0", DELAY_4_0),
-        ("METER_4_0", METER_4_0),
-        ("METER_4_1", METER_4_1),
-        ("METER_4_2", METER_4_2),
-        ("POLARITY_OUT_4_0", POLARITY_OUT_4_0),
         ("PEQ_4_1", PEQ_4_1),
         ("PEQ_4_2", PEQ_4_2),
         ("PEQ_4_3", PEQ_4_3),
@@ -1280,22 +1506,6 @@ pub mod sym {
         ("PEQ_4_8", PEQ_4_8),
         ("PEQ_4_9", PEQ_4_9),
         ("PEQ_4_10", PEQ_4_10),
-        ("BPF_4_1", BPF_4_1),
-        ("BPF_4_5", BPF_4_5),
-        ("D_GAIN_5_0_STATUS", D_GAIN_5_0_STATUS),
-        ("COMP_5_0_STATUS", COMP_5_0_STATUS),
-        ("D_GAIN_5_0", D_GAIN_5_0),
-        ("COMP_5_0_THRESHOLD", COMP_5_0_THRESHOLD),
-        ("COMP_5_0_GAIN", COMP_5_0_GAIN),
-        ("COMP_5_0_RATIO", COMP_5_0_RATIO),
-        ("COMP_5_0_KNEE", COMP_5_0_KNEE),
-        ("COMP_5_0_ATIME", COMP_5_0_ATIME),
-        ("COMP_5_0_RTIME", COMP_5_0_RTIME),
-        ("DELAY_5_0", DELAY_5_0),
-        ("METER_5_0", METER_5_0),
-        ("METER_5_1", METER_5_1),
-        ("METER_5_2", METER_5_2),
-        ("POLARITY_OUT_5_0", POLARITY_OUT_5_0),
         ("PEQ_5_1", PEQ_5_1),
         ("PEQ_5_2", PEQ_5_2),
         ("PEQ_5_3", PEQ_5_3),
@@ -1306,22 +1516,6 @@ pub mod sym {
         ("PEQ_5_8", PEQ_5_8),
         ("PEQ_5_9", PEQ_5_9),
         ("PEQ_5_10", PEQ_5_10),
-        ("BPF_5_1", BPF_5_1),
-        ("BPF_5_5", BPF_5_5),
-        ("D_GAIN_6_0_STATUS", D_GAIN_6_0_STATUS),
-        ("COMP_6_0_STATUS", COMP_6_0_STATUS),
-        ("D_GAIN_6_0", D_GAIN_6_0),
-        ("COMP_6_0_THRESHOLD", COMP_6_0_THRESHOLD),
-        ("COMP_6_0_GAIN", COMP_6_0_GAIN),
-        ("COMP_6_0_RATIO", COMP_6_0_RATIO),
-        ("COMP_6_0_KNEE", COMP_6_0_KNEE),
-        ("COMP_6_0_ATIME", COMP_6_0_ATIME),
-        ("COMP_6_0_RTIME", COMP_6_0_RTIME),
-        ("DELAY_6_0", DELAY_6_0),
-        ("METER_6_0", METER_6_0),
-        ("METER_6_1", METER_6_1),
-        ("METER_6_2", METER_6_2),
-        ("POLARITY_OUT_6_0", POLARITY_OUT_6_0),
         ("PEQ_6_1", PEQ_6_1),
         ("PEQ_6_2", PEQ_6_2),
         ("PEQ_6_3", PEQ_6_3),
@@ -1332,22 +1526,6 @@ pub mod sym {
         ("PEQ_6_8", PEQ_6_8),
         ("PEQ_6_9", PEQ_6_9),
         ("PEQ_6_10", PEQ_6_10),
-        ("BPF_6_1", BPF_6_1),
-        ("BPF_6_5", BPF_6_5),
-        ("D_GAIN_7_0_STATUS", D_GAIN_7_0_STATUS),
-        ("COMP_7_0_STATUS", COMP_7_0_STATUS),
-        ("D_GAIN_7_0", D_GAIN_7_0),
-        ("COMP_7_0_THRESHOLD", COMP_7_0_THRESHOLD),
-        ("COMP_7_0_GAIN", COMP_7_0_GAIN),
-        ("COMP_7_0_RATIO", COMP_7_0_RATIO),
-        ("COMP_7_0_KNEE", COMP_7_0_KNEE),
-        ("COMP_7_0_ATIME", COMP_7_0_ATIME),
-        ("COMP_7_0_RTIME", COMP_7_0_RTIME),
-        ("DELAY_7_0", DELAY_7_0),
-        ("METER_7_0", METER_7_0),
-        ("METER_7_1", METER_7_1),
-        ("METER_7_2", METER_7_2),
-        ("POLARITY_OUT_7_0", POLARITY_OUT_7_0),
         ("PEQ_7_1", PEQ_7_1),
         ("PEQ_7_2", PEQ_7_2),
         ("PEQ_7_3", PEQ_7_3),
@@ -1358,22 +1536,6 @@ pub mod sym {
         ("PEQ_7_8", PEQ_7_8),
         ("PEQ_7_9", PEQ_7_9),
         ("PEQ_7_10", PEQ_7_10),
-        ("BPF_7_1", BPF_7_1),
-        ("BPF_7_5", BPF_7_5),
-        ("D_GAIN_8_0_STATUS", D_GAIN_8_0_STATUS),
-        ("COMP_8_0_STATUS", COMP_8_0_STATUS),
-        ("D_GAIN_8_0", D_GAIN_8_0),
-        ("COMP_8_0_THRESHOLD", COMP_8_0_THRESHOLD),
-        ("COMP_8_0_GAIN", COMP_8_0_GAIN),
-        ("COMP_8_0_RATIO", COMP_8_0_RATIO),
-        ("COMP_8_0_KNEE", COMP_8_0_KNEE),
-        ("COMP_8_0_ATIME", COMP_8_0_ATIME),
-        ("COMP_8_0_RTIME", COMP_8_0_RTIME),
-        ("DELAY_8_0", DELAY_8_0),
-        ("METER_8_0", METER_8_0),
-        ("METER_8_1", METER_8_1),
-        ("METER_8_2", METER_8_2),
-        ("POLARITY_OUT_8_0", POLARITY_OUT_8_0),
         ("PEQ_8_1", PEQ_8_1),
         ("PEQ_8_2", PEQ_8_2),
         ("PEQ_8_3", PEQ_8_3),
@@ -1384,8 +1546,6 @@ pub mod sym {
         ("PEQ_8_8", PEQ_8_8),
         ("PEQ_8_9", PEQ_8_9),
         ("PEQ_8_10", PEQ_8_10),
-        ("BPF_8_1", BPF_8_1),
-        ("BPF_8_5", BPF_8_5),
     ];
 }
 #[allow(unused_imports)]
@@ -1434,7 +1594,10 @@ pub const DEVICE: Device = Device {
                     gain: Some(BM_MIXER_1_8),
                 },
             ],
-            peq: &[],
+            peq: &[
+                PEQ_1_10, PEQ_1_9, PEQ_1_8, PEQ_1_7, PEQ_1_6, PEQ_1_5, PEQ_1_4, PEQ_1_3, PEQ_1_2,
+                PEQ_1_1,
+            ],
         },
         Input {
             gate: Some(Gate {
@@ -1476,7 +1639,10 @@ pub const DEVICE: Device = Device {
                     gain: Some(BM_MIXER_2_8),
                 },
             ],
-            peq: &[],
+            peq: &[
+                PEQ_2_10, PEQ_2_9, PEQ_2_8, PEQ_2_7, PEQ_2_6, PEQ_2_5, PEQ_2_4, PEQ_2_3, PEQ_2_2,
+                PEQ_2_1,
+            ],
         },
         Input {
             gate: Some(Gate {
@@ -1518,7 +1684,10 @@ pub const DEVICE: Device = Device {
                     gain: Some(BM_MIXER_3_8),
                 },
             ],
-            peq: &[],
+            peq: &[
+                PEQ_3_10, PEQ_3_9, PEQ_3_8, PEQ_3_7, PEQ_3_6, PEQ_3_5, PEQ_3_4, PEQ_3_3, PEQ_3_2,
+                PEQ_3_1,
+            ],
         },
         Input {
             gate: Some(Gate {
@@ -1560,7 +1729,10 @@ pub const DEVICE: Device = Device {
                     gain: Some(BM_MIXER_4_8),
                 },
             ],
-            peq: &[],
+            peq: &[
+                PEQ_4_10, PEQ_4_9, PEQ_4_8, PEQ_4_7, PEQ_4_6, PEQ_4_5, PEQ_4_4, PEQ_4_3, PEQ_4_2,
+                PEQ_4_1,
+            ],
         },
         Input {
             gate: Some(Gate {
@@ -1602,7 +1774,10 @@ pub const DEVICE: Device = Device {
                     gain: Some(BM_MIXER_5_8),
                 },
             ],
-            peq: &[],
+            peq: &[
+                PEQ_5_10, PEQ_5_9, PEQ_5_8, PEQ_5_7, PEQ_5_6, PEQ_5_5, PEQ_5_4, PEQ_5_3, PEQ_5_2,
+                PEQ_5_1,
+            ],
         },
         Input {
             gate: Some(Gate {
@@ -1644,7 +1819,10 @@ pub const DEVICE: Device = Device {
                     gain: Some(BM_MIXER_6_8),
                 },
             ],
-            peq: &[],
+            peq: &[
+                PEQ_6_10, PEQ_6_9, PEQ_6_8, PEQ_6_7, PEQ_6_6, PEQ_6_5, PEQ_6_4, PEQ_6_3, PEQ_6_2,
+                PEQ_6_1,
+            ],
         },
         Input {
             gate: Some(Gate {
@@ -1686,7 +1864,10 @@ pub const DEVICE: Device = Device {
                     gain: Some(BM_MIXER_7_8),
                 },
             ],
-            peq: &[],
+            peq: &[
+                PEQ_7_10, PEQ_7_9, PEQ_7_8, PEQ_7_7, PEQ_7_6, PEQ_7_5, PEQ_7_4, PEQ_7_3, PEQ_7_2,
+                PEQ_7_1,
+            ],
         },
         Input {
             gate: Some(Gate {
@@ -1728,207 +1909,186 @@ pub const DEVICE: Device = Device {
                     gain: Some(BM_MIXER_8_8),
                 },
             ],
-            peq: &[],
+            peq: &[
+                PEQ_8_10, PEQ_8_9, PEQ_8_8, PEQ_8_7, PEQ_8_6, PEQ_8_5, PEQ_8_4, PEQ_8_3, PEQ_8_2,
+                PEQ_8_1,
+            ],
         },
     ],
     outputs: &[
         Output {
             gate: Gate {
-                enable: D_GAIN_1_0_STATUS,
-                gain: Some(D_GAIN_1_0),
+                enable: D_GAIN_9_0_STATUS,
+                gain: Some(D_GAIN_9_0),
             },
-            meter: Some(METER_OUT_1),
-            delay_addr: Some(DELAY_1_0),
-            invert_addr: POLARITY_OUT_1_0,
-            peq: &[
-                PEQ_1_10, PEQ_1_9, PEQ_1_8, PEQ_1_7, PEQ_1_6, PEQ_1_5, PEQ_1_4, PEQ_1_3, PEQ_1_2,
-                PEQ_1_1,
-            ],
+            meter: Some(METER_OUT_9),
+            delay_addr: Some(DELAY_9_0),
+            invert_addr: POLARITY_OUT_9_0,
+            peq: &[],
             xover: Some(Crossover {
-                peqs: &[BPF_1_1, BPF_1_5, BM_BPF_1_1, BM_BPF_1_5],
+                peqs: &[BPF_9_1, BPF_9_5, BM_BPF_1_1, BM_BPF_1_5],
             }),
             compressor: Some(Compressor {
-                bypass: COMP_1_0_STATUS,
-                threshold: COMP_1_0_THRESHOLD,
-                ratio: COMP_1_0_RATIO,
-                attack: COMP_1_0_ATIME,
-                release: COMP_1_0_RTIME,
-                meter: Some(METER_COMP_1),
+                bypass: COMP_9_0_STATUS,
+                threshold: COMP_9_0_THRESHOLD,
+                ratio: COMP_9_0_RATIO,
+                attack: COMP_9_0_ATIME,
+                release: COMP_9_0_RTIME,
+                meter: Some(METER_COMP_9),
             }),
             fir: None,
         },
         Output {
             gate: Gate {
-                enable: D_GAIN_2_0_STATUS,
-                gain: Some(D_GAIN_2_0),
+                enable: D_GAIN_10_0_STATUS,
+                gain: Some(D_GAIN_10_0),
             },
-            meter: Some(METER_OUT_2),
-            delay_addr: Some(DELAY_2_0),
-            invert_addr: POLARITY_OUT_2_0,
-            peq: &[
-                PEQ_2_10, PEQ_2_9, PEQ_2_8, PEQ_2_7, PEQ_2_6, PEQ_2_5, PEQ_2_4, PEQ_2_3, PEQ_2_2,
-                PEQ_2_1,
-            ],
+            meter: Some(METER_OUT_10),
+            delay_addr: Some(DELAY_10_0),
+            invert_addr: POLARITY_OUT_10_0,
+            peq: &[],
             xover: Some(Crossover {
-                peqs: &[BPF_2_1, BPF_2_5, BM_BPF_2_1, BM_BPF_2_5],
+                peqs: &[BPF_10_1, BPF_10_5, BM_BPF_2_1, BM_BPF_2_5],
             }),
             compressor: Some(Compressor {
-                bypass: COMP_2_0_STATUS,
-                threshold: COMP_2_0_THRESHOLD,
-                ratio: COMP_2_0_RATIO,
-                attack: COMP_2_0_ATIME,
-                release: COMP_2_0_RTIME,
-                meter: Some(METER_COMP_2),
+                bypass: COMP_10_0_STATUS,
+                threshold: COMP_10_0_THRESHOLD,
+                ratio: COMP_10_0_RATIO,
+                attack: COMP_10_0_ATIME,
+                release: COMP_10_0_RTIME,
+                meter: Some(METER_COMP_10),
             }),
             fir: None,
         },
         Output {
             gate: Gate {
-                enable: D_GAIN_3_0_STATUS,
-                gain: Some(D_GAIN_3_0),
+                enable: D_GAIN_11_0_STATUS,
+                gain: Some(D_GAIN_11_0),
             },
-            meter: Some(METER_OUT_3),
-            delay_addr: Some(DELAY_3_0),
-            invert_addr: POLARITY_OUT_3_0,
-            peq: &[
-                PEQ_3_10, PEQ_3_9, PEQ_3_8, PEQ_3_7, PEQ_3_6, PEQ_3_5, PEQ_3_4, PEQ_3_3, PEQ_3_2,
-                PEQ_3_1,
-            ],
+            meter: Some(METER_OUT_11),
+            delay_addr: Some(DELAY_11_0),
+            invert_addr: POLARITY_OUT_11_0,
+            peq: &[],
             xover: Some(Crossover {
-                peqs: &[BPF_3_1, BPF_3_5, BM_BPF_3_1, BM_BPF_3_5],
+                peqs: &[BPF_11_1, BPF_11_5, BM_BPF_3_1, BM_BPF_3_5],
             }),
             compressor: Some(Compressor {
-                bypass: COMP_3_0_STATUS,
-                threshold: COMP_3_0_THRESHOLD,
-                ratio: COMP_3_0_RATIO,
-                attack: COMP_3_0_ATIME,
-                release: COMP_3_0_RTIME,
-                meter: Some(METER_COMP_3),
+                bypass: COMP_11_0_STATUS,
+                threshold: COMP_11_0_THRESHOLD,
+                ratio: COMP_11_0_RATIO,
+                attack: COMP_11_0_ATIME,
+                release: COMP_11_0_RTIME,
+                meter: Some(METER_COMP_11),
             }),
             fir: None,
         },
         Output {
             gate: Gate {
-                enable: D_GAIN_4_0_STATUS,
-                gain: Some(D_GAIN_4_0),
+                enable: D_GAIN_12_0_STATUS,
+                gain: Some(D_GAIN_12_0),
             },
-            meter: Some(METER_OUT_4),
-            delay_addr: Some(DELAY_4_0),
-            invert_addr: POLARITY_OUT_4_0,
-            peq: &[
-                PEQ_4_10, PEQ_4_9, PEQ_4_8, PEQ_4_7, PEQ_4_6, PEQ_4_5, PEQ_4_4, PEQ_4_3, PEQ_4_2,
-                PEQ_4_1,
-            ],
+            meter: Some(METER_OUT_12),
+            delay_addr: Some(DELAY_12_0),
+            invert_addr: POLARITY_OUT_12_0,
+            peq: &[],
             xover: Some(Crossover {
-                peqs: &[BPF_4_1, BPF_4_5, BM_BPF_4_1, BM_BPF_4_5],
+                peqs: &[BPF_12_1, BPF_12_5, BM_BPF_4_1, BM_BPF_4_5],
             }),
             compressor: Some(Compressor {
-                bypass: COMP_4_0_STATUS,
-                threshold: COMP_4_0_THRESHOLD,
-                ratio: COMP_4_0_RATIO,
-                attack: COMP_4_0_ATIME,
-                release: COMP_4_0_RTIME,
-                meter: Some(METER_COMP_4),
+                bypass: COMP_12_0_STATUS,
+                threshold: COMP_12_0_THRESHOLD,
+                ratio: COMP_12_0_RATIO,
+                attack: COMP_12_0_ATIME,
+                release: COMP_12_0_RTIME,
+                meter: Some(METER_COMP_12),
             }),
             fir: None,
         },
         Output {
             gate: Gate {
-                enable: D_GAIN_5_0_STATUS,
-                gain: Some(D_GAIN_5_0),
+                enable: D_GAIN_13_0_STATUS,
+                gain: Some(D_GAIN_13_0),
             },
-            meter: Some(METER_OUT_5),
-            delay_addr: Some(DELAY_5_0),
-            invert_addr: POLARITY_OUT_5_0,
-            peq: &[
-                PEQ_5_10, PEQ_5_9, PEQ_5_8, PEQ_5_7, PEQ_5_6, PEQ_5_5, PEQ_5_4, PEQ_5_3, PEQ_5_2,
-                PEQ_5_1,
-            ],
+            meter: Some(METER_OUT_13),
+            delay_addr: Some(DELAY_13_0),
+            invert_addr: POLARITY_OUT_13_0,
+            peq: &[],
             xover: Some(Crossover {
-                peqs: &[BPF_5_1, BPF_5_5, BM_BPF_5_1, BM_BPF_5_5],
+                peqs: &[BPF_13_1, BPF_13_5, BM_BPF_5_1, BM_BPF_5_5],
             }),
             compressor: Some(Compressor {
-                bypass: COMP_5_0_STATUS,
-                threshold: COMP_5_0_THRESHOLD,
-                ratio: COMP_5_0_RATIO,
-                attack: COMP_5_0_ATIME,
-                release: COMP_5_0_RTIME,
-                meter: Some(METER_COMP_5),
+                bypass: COMP_13_0_STATUS,
+                threshold: COMP_13_0_THRESHOLD,
+                ratio: COMP_13_0_RATIO,
+                attack: COMP_13_0_ATIME,
+                release: COMP_13_0_RTIME,
+                meter: Some(METER_COMP_13),
             }),
             fir: None,
         },
         Output {
             gate: Gate {
-                enable: D_GAIN_6_0_STATUS,
-                gain: Some(D_GAIN_6_0),
+                enable: D_GAIN_14_0_STATUS,
+                gain: Some(D_GAIN_14_0),
             },
-            meter: Some(METER_OUT_6),
-            delay_addr: Some(DELAY_6_0),
-            invert_addr: POLARITY_OUT_6_0,
-            peq: &[
-                PEQ_6_10, PEQ_6_9, PEQ_6_8, PEQ_6_7, PEQ_6_6, PEQ_6_5, PEQ_6_4, PEQ_6_3, PEQ_6_2,
-                PEQ_6_1,
-            ],
+            meter: Some(METER_OUT_14),
+            delay_addr: Some(DELAY_14_0),
+            invert_addr: POLARITY_OUT_14_0,
+            peq: &[],
             xover: Some(Crossover {
-                peqs: &[BPF_6_1, BPF_6_5, BM_BPF_6_1, BM_BPF_6_5],
+                peqs: &[BPF_14_1, BPF_14_5, BM_BPF_6_1, BM_BPF_6_5],
             }),
             compressor: Some(Compressor {
-                bypass: COMP_6_0_STATUS,
-                threshold: COMP_6_0_THRESHOLD,
-                ratio: COMP_6_0_RATIO,
-                attack: COMP_6_0_ATIME,
-                release: COMP_6_0_RTIME,
-                meter: Some(METER_COMP_6),
+                bypass: COMP_14_0_STATUS,
+                threshold: COMP_14_0_THRESHOLD,
+                ratio: COMP_14_0_RATIO,
+                attack: COMP_14_0_ATIME,
+                release: COMP_14_0_RTIME,
+                meter: Some(METER_COMP_14),
             }),
             fir: None,
         },
         Output {
             gate: Gate {
-                enable: D_GAIN_7_0_STATUS,
-                gain: Some(D_GAIN_7_0),
+                enable: D_GAIN_15_0_STATUS,
+                gain: Some(D_GAIN_15_0),
             },
-            meter: Some(METER_OUT_7),
-            delay_addr: Some(DELAY_7_0),
-            invert_addr: POLARITY_OUT_7_0,
-            peq: &[
-                PEQ_7_10, PEQ_7_9, PEQ_7_8, PEQ_7_7, PEQ_7_6, PEQ_7_5, PEQ_7_4, PEQ_7_3, PEQ_7_2,
-                PEQ_7_1,
-            ],
+            meter: Some(METER_OUT_15),
+            delay_addr: Some(DELAY_15_0),
+            invert_addr: POLARITY_OUT_15_0,
+            peq: &[],
             xover: Some(Crossover {
-                peqs: &[BPF_7_1, BPF_7_5, BM_BPF_7_1, BM_BPF_7_5],
+                peqs: &[BPF_15_1, BPF_15_5, BM_BPF_7_1, BM_BPF_7_5],
             }),
             compressor: Some(Compressor {
-                bypass: COMP_7_0_STATUS,
-                threshold: COMP_7_0_THRESHOLD,
-                ratio: COMP_7_0_RATIO,
-                attack: COMP_7_0_ATIME,
-                release: COMP_7_0_RTIME,
-                meter: Some(METER_COMP_7),
+                bypass: COMP_15_0_STATUS,
+                threshold: COMP_15_0_THRESHOLD,
+                ratio: COMP_15_0_RATIO,
+                attack: COMP_15_0_ATIME,
+                release: COMP_15_0_RTIME,
+                meter: Some(METER_COMP_15),
             }),
             fir: None,
         },
         Output {
             gate: Gate {
-                enable: D_GAIN_8_0_STATUS,
-                gain: Some(D_GAIN_8_0),
+                enable: D_GAIN_16_0_STATUS,
+                gain: Some(D_GAIN_16_0),
             },
-            meter: Some(METER_OUT_8),
-            delay_addr: Some(DELAY_8_0),
-            invert_addr: POLARITY_OUT_8_0,
-            peq: &[
-                PEQ_8_10, PEQ_8_9, PEQ_8_8, PEQ_8_7, PEQ_8_6, PEQ_8_5, PEQ_8_4, PEQ_8_3, PEQ_8_2,
-                PEQ_8_1,
-            ],
+            meter: Some(METER_OUT_16),
+            delay_addr: Some(DELAY_16_0),
+            invert_addr: POLARITY_OUT_16_0,
+            peq: &[],
             xover: Some(Crossover {
-                peqs: &[BPF_8_1, BPF_8_5, BM_BPF_8_1, BM_BPF_8_5],
+                peqs: &[BPF_16_1, BPF_16_5, BM_BPF_8_1, BM_BPF_8_5],
             }),
             compressor: Some(Compressor {
-                bypass: COMP_8_0_STATUS,
-                threshold: COMP_8_0_THRESHOLD,
-                ratio: COMP_8_0_RATIO,
-                attack: COMP_8_0_ATIME,
-                release: COMP_8_0_RTIME,
-                meter: Some(METER_COMP_8),
+                bypass: COMP_16_0_STATUS,
+                threshold: COMP_16_0_THRESHOLD,
+                ratio: COMP_16_0_RATIO,
+                attack: COMP_16_0_ATIME,
+                release: COMP_16_0_RTIME,
+                meter: Some(METER_COMP_16),
             }),
             fir: None,
         },

--- a/protocol/src/device/probe.rs
+++ b/protocol/src/device/probe.rs
@@ -41,8 +41,6 @@ pub enum DeviceKind {
     M2x4,
     #[cfg(feature = "device_flex")]
     Flex,
-    #[cfg(feature = "device_flexdl")]
-    FlexDl,
     #[cfg(feature = "device_flexhtx")]
     FlexHtx,
 }
@@ -78,10 +76,9 @@ pub fn probe_kind(device_info: &DeviceInfo) -> DeviceKind {
         (2, 22) => M2x4,
         #[cfg(feature = "device_flex")]
         (27, 100) => Flex,
-        #[cfg(feature = "device_flexdl")]
-        (27, 101) => FlexDl,
+
         #[cfg(feature = "device_flexhtx")]
-        (32, 113) => FlexHtx, //get from `minidsp probe`
+        (32, 115) => FlexHtx, //get from `minidsp probe`
 
         _ => Generic,
     }
@@ -124,9 +121,6 @@ pub fn by_kind(kind: DeviceKind) -> &'static super::Device {
 
         #[cfg(feature = "device_flex")]
         Flex => &super::flex::DEVICE,
-
-        #[cfg(feature = "device_flexdl")]
-        FlexDl => &super::flexdl::DEVICE,
 
         #[cfg(feature = "device_flexhtx")]
         FlexHtx => &super::flexhtx::DEVICE,


### PR DESCRIPTION
## Summary

Fix Flex HTx support by correcting the PEQ writes to input channels, adding support for new MiniDSP added feature

## Root Cause

The existing implementation had PEQ blocks on output channels, as a workaround waiting for input PEQ support.

Once MiniDSP patched the Flex HTx to include input PEQ, this change was needed in order to bring this device inline with other MiniDSP devices.

## Changes

- updated `devtools/src/codegen/flexhtx/config.xml` using a Flex HTx export
   - config file now properly targets updated address blocks for input PEQ's
- updated `devtools/src/codegen/flexhtx/mod.rs`:
  - moved PEQ generation from outputs to inputs
  - removed output PEQ definitions
  - corrected output control indexing (removed offset mapping)
- regenerated `protocol/src/device/flexhtx.rs`
- updated `protocol/src/device/probe.rs`:
  - detect Flex HTx using DSP version `115` (previously `113`)

## Validation

Tested on real Flex HTx hardware:

- CLI writes to input PEQ apply correctly
- EZBEQ and manual biquad entry now produce matching results
- REW confirms filters are applied as expected
- device correctly identified as Flex HTx