### PR TITLE
feat: named aliases for input/output channels

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -208,8 +208,8 @@ checksum = "e37668cb35145dcfaa1931a5f37fde375eeae8068b4c0d2f289da28a270b2d2c"
 dependencies = [
  "directories",
  "serde",
- "thiserror",
- "toml",
+ "thiserror 1.0.69",
+ "toml 0.5.11",
 ]
 
 [[package]]
@@ -253,7 +253,16 @@ version = "4.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f51c5d4ddabd36886dd3e1438cb358cdcb0d7c499cb99cb4ac2e38e18b5cb210"
 dependencies = [
- "dirs-sys",
+ "dirs-sys 0.3.7",
+]
+
+[[package]]
+name = "dirs"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
+dependencies = [
+ "dirs-sys 0.5.0",
 ]
 
 [[package]]
@@ -263,8 +272,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
 dependencies = [
  "libc",
- "redox_users",
+ "redox_users 0.4.6",
  "winapi",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users 0.5.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -296,6 +317,12 @@ dependencies = [
  "regex",
  "termcolor",
 ]
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "find-msvc-tools"
@@ -426,6 +453,12 @@ dependencies = [
  "libc",
  "wasi",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "heck"
@@ -682,6 +715,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+dependencies = [
+ "equivalent",
+ "hashbrown",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "is-terminal"
 version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -689,7 +734,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi 0.5.2",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -760,6 +805,7 @@ dependencies = [
  "bimap",
  "bytes",
  "clap",
+ "dirs",
  "env_logger",
  "futures",
  "futures-sink",
@@ -770,6 +816,7 @@ dependencies = [
  "hidapi",
  "hyper",
  "hyperlocal",
+ "indexmap",
  "lazy_static",
  "log",
  "minidsp-protocol",
@@ -781,11 +828,12 @@ dependencies = [
  "strong-xml",
  "strum",
  "termcolor",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
  "tokio-stream",
  "tokio-tungstenite",
  "tokio-util",
+ "toml 1.1.2+spec-1.1.0",
  "tower",
  "url2",
  "urlencoding",
@@ -820,7 +868,7 @@ dependencies = [
  "serde_json",
  "strum",
  "termcolor",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -857,7 +905,7 @@ dependencies = [
  "schemars",
  "serde",
  "strum",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -894,6 +942,12 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "percent-encoding"
@@ -1007,7 +1061,18 @@ checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
  "getrandom",
  "libredox",
- "thiserror",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
+dependencies = [
+ "getrandom",
+ "libredox",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1164,6 +1229,15 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+dependencies = [
+ "serde_core",
 ]
 
 [[package]]
@@ -1331,7 +1405,16 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -1339,6 +1422,17 @@ name = "thiserror-impl"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1428,6 +1522,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow",
+]
+
+[[package]]
+name = "toml_writer"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
+
+[[package]]
 name = "tower"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1495,7 +1628,7 @@ dependencies = [
  "log",
  "rand",
  "sha1",
- "thiserror",
+ "thiserror 1.0.69",
  "url",
  "utf-8",
 ]
@@ -1611,7 +1744,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1707,6 +1840,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 
 [[package]]
 name = "writeable"

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -6,6 +6,7 @@
   - [Bass EQ](./integrations/beq.md)
   - [Roomie Remote](./integrations/roomie_remote.md)
 - [Command Line Interface](./cli/index.md)
+  - [Channel Names](./cli/names.md)
   - [Master Settings](./cli/master/index.md)
     - [Config](./cli/master/config.md)
     - [Source](./cli/master/source.md)

--- a/docs/src/cli/index.md
+++ b/docs/src/cli/index.md
@@ -55,6 +55,14 @@ The following settings will be visible after changing them from any source:
 The rest of the settings (filters, delays, routing) will not be reflected in the app.
 
 
+### Channel names
+Input and output channels can be given names for convenience. See [Channel Names](./names.md) for details.
+
+```bash
+minidsp name output 0 left
+minidsp output left gain -- -10
+```
+
 ### Running multiple commands at once
 For the purposes of organizing configurations, a file can be created with commands to run sequentially. It's an easy way to recall a certain preset without changing the device config preset.
 

--- a/docs/src/cli/names.md
+++ b/docs/src/cli/names.md
@@ -1,0 +1,96 @@
+# Channel Names
+
+You can assign human-readable names to input and output channels. Names are stored per-device (identified by serial number) in `~/.config/minidsp/names.toml`.
+
+## Setting names
+
+A device must be connected when assigning names:
+
+```bash
+minidsp name input 0 left
+minidsp name input 1 right
+minidsp name output 0 left
+minidsp name output 1 right
+minidsp name output 2 sub_left
+minidsp name output 3 sub_right
+```
+
+## Using names
+
+Anywhere a channel index is accepted, you can use a name instead:
+
+```bash
+minidsp output left gain -- -10
+minidsp output sub_left fir load filter.wav
+minidsp input left routing right gain -- -3
+```
+
+Numeric indices still work as before:
+
+```bash
+minidsp output 0 gain -- -10
+```
+
+## Status display
+
+When names are configured, `minidsp status` shows them in the text output:
+
+```
+MasterStatus { preset: 0, source: Toslink, volume: Gain(-8.0), mute: false, dirac: false }
+Input levels: left: -61.6, right: -57.9
+Output levels: left: -67.9, right: -71.6, sub_left: -120.0, sub_right: -120.0
+```
+
+JSON output (`-o json`) is unaffected.
+
+## Listing names
+
+Works without a device connected:
+
+```bash
+$ minidsp name list
+device 902106:
+  input  0: left
+  input  1: right
+  output 0: left, main_l
+  output 1: right
+  output 2: sub_left
+  output 3: sub_right
+```
+
+## Aliases
+
+Multiple names can point to the same channel:
+
+```bash
+minidsp name output 0 left
+minidsp name output 0 main_l
+```
+
+The first name appearing in the config file for a given index is used in status display. You can reorder entries in `~/.config/minidsp/names.toml` to change which name is preferred.
+
+## Removing names
+
+```bash
+minidsp name remove sub_right
+```
+
+## Config file format
+
+```toml
+[device.902106.inputs]
+left = 0
+right = 1
+
+[device.902106.outputs]
+left = 0
+right = 1
+sub_left = 2
+sub_right = 3
+```
+
+## Notes
+
+- Names cannot be pure numbers (to avoid ambiguity with indices)
+- Names are stored per device serial number, so multiple devices can have independent names
+- The config file is at `~/.config/minidsp/names.toml`

--- a/minidsp/Cargo.toml
+++ b/minidsp/Cargo.toml
@@ -16,6 +16,9 @@ atomic_refcell = "0.1.14"
 bimap = "0.6.3"
 bytes = "1.11.1"
 clap = { version = "4.6.1", features = ["derive", "env"] }
+dirs = "6"
+indexmap = { version = "2", features = ["serde"] }
+toml = "1"
 env_logger = "0.10.2"
 futures = "0.3.32"
 futures-sink = "0.3.32"

--- a/minidsp/src/bin/minidsp/handlers.rs
+++ b/minidsp/src/bin/minidsp/handlers.rs
@@ -1,5 +1,7 @@
 use std::{str::FromStr, time::Duration};
 
+use indexmap::IndexMap;
+
 use minidsp::{
     formats::{rew::FromRew, wav::read_wav_filter},
     model::StatusSummary,
@@ -8,7 +10,7 @@ use minidsp::{
 };
 
 use super::{InputCommand, MiniDSP, OutputCommand, Result};
-use crate::{debug::run_debug, FilterCommand, PEQTarget, RoutingCommand, SubCommand, ToggleBool};
+use crate::{debug::run_debug, FilterCommand, NameCommand, PEQTarget, RoutingCommand, SubCommand, ToggleBool};
 
 pub(crate) async fn run_server(
     subcmd: SubCommand,
@@ -62,6 +64,9 @@ pub(crate) async fn run_command(
     cmd: Option<&SubCommand>,
     opts: &crate::Opts,
 ) -> Result<()> {
+    let serial = device.get_device_info().await?.serial;
+    let names_cfg = crate::names::NamesConfig::load();
+    let names = names_cfg.for_device(serial);
     match cmd {
         // Master
         Some(&SubCommand::Gain {
@@ -93,13 +98,19 @@ pub(crate) async fn run_command(
             device.set_dirac(dirac).await?
         }
         Some(&SubCommand::Input {
-            input_index,
+            ref input_index,
             ref cmd,
-        }) => run_input(device, cmd, input_index).await?,
+        }) => {
+            let idx = names.resolve_input(input_index)?;
+            run_input(device, cmd, idx, &names).await?
+        }
         Some(&SubCommand::Output {
-            output_index,
+            ref output_index,
             ref cmd,
-        }) => run_output(device, output_index, cmd).await?,
+        }) => {
+            let idx = names.resolve_output(output_index)?;
+            run_output(device, idx, cmd).await?
+        }
 
         // Other tools
         Some(SubCommand::Debug { cmd }) => run_debug(device, cmd).await?,
@@ -107,11 +118,15 @@ pub(crate) async fn run_command(
         // Handled earlier
         Some(&SubCommand::Server { .. }) => {}
         Some(&SubCommand::Probe { .. }) => return Ok(()),
+        Some(SubCommand::Name { .. }) => return Ok(()),
 
         Some(&SubCommand::Status) | None => {
             // Always output the current master status and input/output levels
             let summary = StatusSummary::fetch(device).await?;
-            println!("{}", opts.output_format.format(&summary));
+            match opts.output_format {
+                crate::OutputFormat::Text => print_status_with_names(&summary, &names),
+                _ => println!("{}", opts.output_format.format(&summary)),
+            }
         }
     };
 
@@ -122,6 +137,7 @@ pub(crate) async fn run_input(
     dsp: &MiniDSP<'_>,
     cmd: &InputCommand,
     input_index: usize,
+    names: &crate::names::DeviceNames,
 ) -> Result<()> {
     use InputCommand::*;
     use RoutingCommand::*;
@@ -131,12 +147,15 @@ pub(crate) async fn run_input(
         InputCommand::Gain { value } => input.set_gain(value).await?,
         Mute { value } => input.set_mute(value.0).await?,
         Routing {
-            output_index,
+            ref output_index,
             ref cmd,
-        } => match *cmd {
-            Enable { value } => input.set_output_enable(output_index, value.0).await?,
-            RoutingCommand::Gain { value } => input.set_output_gain(output_index, value).await?,
-        },
+        } => {
+            let output_index = names.resolve_output(output_index)?;
+            match *cmd {
+                Enable { value } => input.set_output_enable(output_index, value.0).await?,
+                RoutingCommand::Gain { value } => input.set_output_gain(output_index, value).await?,
+            }
+        }
         PEQ { index, ref cmd } => match index {
             PEQTarget::One(index) => run_peq(&[input.peq(index)?], cmd).await?,
             PEQTarget::All => {
@@ -345,4 +364,87 @@ pub(crate) async fn run_fir(dsp: &MiniDSP<'_>, fir: &Fir<'_>, cmd: &FilterComman
     }
 
     Ok(())
+}
+
+fn print_status_with_names(summary: &StatusSummary, names: &crate::names::DeviceNames) {
+    println!("{:?}", summary.master);
+
+    let fmt_levels = |levels: &[f32], labeler: fn(&crate::names::DeviceNames, usize) -> String| -> String {
+        levels.iter().enumerate()
+            .map(|(i, level)| format!("{}: {:.1}", labeler(names, i), level))
+            .collect::<Vec<_>>()
+            .join(", ")
+    };
+
+    println!("Input levels: {}", fmt_levels(&summary.input_levels, crate::names::DeviceNames::label_for_input));
+    println!("Output levels: {}", fmt_levels(&summary.output_levels, crate::names::DeviceNames::label_for_output));
+}
+
+pub(crate) fn run_name_command(cmd: &NameCommand, serial: Option<u32>) {
+    let mut config = crate::names::NamesConfig::load();
+    match cmd {
+        NameCommand::Input { index, name } | NameCommand::Output { index, name } => {
+            let serial = serial.expect("device must be connected to set names");
+            if let Err(e) = crate::names::NamesConfig::validate_name(name) {
+                eprintln!("error: {}", e);
+                return;
+            }
+            let (kind, map) = {
+                let dev = config.for_device_mut(serial);
+                if matches!(cmd, NameCommand::Input { .. }) {
+                    ("input", &mut dev.inputs)
+                } else {
+                    ("output", &mut dev.outputs)
+                }
+            };
+            if let Some(old) = map.insert(name.clone(), *index) {
+                if old != *index {
+                    eprintln!("note: '{}' was previously mapped to {} {}", name, kind, old);
+                }
+            }
+            config.save().expect("failed to save names config");
+            println!("{} {} = {}", kind, name, index);
+        }
+        NameCommand::Remove { name } => {
+            let serial = serial.expect("device must be connected to remove names");
+            let dev = config.for_device_mut(serial);
+            let removed = dev.inputs.shift_remove(name).is_some()
+                || dev.outputs.shift_remove(name).is_some();
+            if removed {
+                config.save().expect("failed to save names config");
+                println!("removed '{}'", name);
+            } else {
+                eprintln!("name '{}' not found", name);
+            }
+        }
+        NameCommand::List => {
+            if config.device.is_empty() {
+                println!("no names configured");
+                return;
+            }
+            for (serial, dev) in &config.device {
+                if dev.inputs.is_empty() && dev.outputs.is_empty() {
+                    continue;
+                }
+                println!("device {}:", serial);
+                print_grouped("  input", &dev.inputs);
+                print_grouped("  output", &dev.outputs);
+            }
+        }
+    }
+}
+
+fn print_grouped(kind: &str, map: &IndexMap<String, usize>) {
+    if map.is_empty() {
+        return;
+    }
+    // Group names by index, preserving insertion order for each group
+    let mut groups: IndexMap<usize, Vec<&str>> = IndexMap::new();
+    for (name, &idx) in map {
+        groups.entry(idx).or_default().push(name.as_str());
+    }
+    groups.sort_keys();
+    for (idx, names) in &groups {
+        println!("{:<6} {}: {}", kind, idx, names.join(", "));
+    }
 }

--- a/minidsp/src/bin/minidsp/main.rs
+++ b/minidsp/src/bin/minidsp/main.rs
@@ -27,6 +27,7 @@ use minidsp::{
 
 mod debug;
 mod handlers;
+mod names;
 
 use std::{io::Read, time::Duration};
 
@@ -191,8 +192,8 @@ enum SubCommand {
 
     /// Control settings regarding input channels
     Input {
-        /// Index of the input channel, starting at 0
-        input_index: usize,
+        /// Index or name of the input channel, starting at 0
+        input_index: String,
 
         #[clap(subcommand)]
         cmd: InputCommand,
@@ -200,8 +201,8 @@ enum SubCommand {
 
     /// Control settings regarding output channels
     Output {
-        /// Index of the output channel, starting at 0
-        output_index: usize,
+        /// Index or name of the output channel, starting at 0
+        output_index: String,
 
         #[clap(subcommand)]
         cmd: OutputCommand,
@@ -221,6 +222,12 @@ enum SubCommand {
     Debug {
         #[clap(subcommand)]
         cmd: DebugCommands,
+    },
+
+    /// Manage named aliases for input/output channels
+    Name {
+        #[clap(subcommand)]
+        cmd: NameCommand,
     },
 }
 
@@ -263,6 +270,31 @@ impl FromStr for Bool {
 }
 
 #[derive(Clone, Parser, Debug)]
+enum NameCommand {
+    /// Assign a name to an input channel
+    Input {
+        /// 0-based channel index
+        index: usize,
+        /// Name to assign
+        name: String,
+    },
+    /// Assign a name to an output channel
+    Output {
+        /// 0-based channel index
+        index: usize,
+        /// Name to assign
+        name: String,
+    },
+    /// Remove a named alias
+    Remove {
+        /// Name to remove
+        name: String,
+    },
+    /// List all named aliases
+    List,
+}
+
+#[derive(Clone, Parser, Debug)]
 enum InputCommand {
     /// Set the input gain for this channel
     Gain {
@@ -278,8 +310,8 @@ enum InputCommand {
 
     /// Controls signal routing from this input
     Routing {
-        /// Index of the output channel starting at 0
-        output_index: usize,
+        /// Index or name of the output channel starting at 0
+        output_index: String,
 
         #[clap(subcommand)]
         cmd: RoutingCommand,
@@ -536,6 +568,14 @@ async fn main() -> Result<()> {
         return Ok(());
     }
 
+    if let Some(SubCommand::Name { ref cmd }) = opts.subcmd {
+        if matches!(cmd, crate::NameCommand::List) {
+            handlers::run_name_command(cmd, None);
+            return Ok(());
+        }
+        // Other name commands need a device — fall through to device probe
+    }
+
     if !opts.all_local_devices {
         if let Some(index) = opts.device_index {
             let dev = devices.remove(index);
@@ -543,6 +583,12 @@ async fn main() -> Result<()> {
             devices.push(dev);
         }
         devices.truncate(1);
+    }
+
+    if let Some(SubCommand::Name { ref cmd }) = opts.subcmd {
+        let device = devices.first().ok_or_else(|| anyhow!("No devices found"))?;
+        handlers::run_name_command(cmd, Some(device.device_info.serial));
+        return Ok(());
     }
 
     if let Some(SubCommand::Server { .. }) = opts.subcmd {
@@ -648,14 +694,14 @@ mod tests {
             v,
             Ok(Opts {
                 subcmd: Some(SubCommand::Input {
-                    input_index: 0,
+                    ref input_index,
                     cmd: InputCommand::PEQ {
                         index: PEQTarget::One(0),
                         cmd: FilterCommand::Bypass { value: Bool(false) },
                     },
                 }),
                 ..
-            })
+            }) if input_index == "0"
         ));
     }
 }

--- a/minidsp/src/bin/minidsp/names.rs
+++ b/minidsp/src/bin/minidsp/names.rs
@@ -1,0 +1,172 @@
+use std::collections::HashMap;
+use std::fs;
+use std::path::PathBuf;
+
+use anyhow::{anyhow, Result};
+use indexmap::IndexMap;
+use serde::{Deserialize, Serialize};
+
+#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+pub struct DeviceNames {
+    #[serde(default)]
+    pub inputs: IndexMap<String, usize>,
+    #[serde(default)]
+    pub outputs: IndexMap<String, usize>,
+}
+
+#[derive(Default, Debug, Serialize, Deserialize)]
+pub struct NamesConfig {
+    #[serde(default)]
+    pub device: HashMap<String, DeviceNames>,
+}
+
+impl NamesConfig {
+    fn path() -> Option<PathBuf> {
+        dirs::config_dir().map(|d| d.join("minidsp").join("names.toml"))
+    }
+
+    pub fn load() -> Self {
+        Self::path()
+            .and_then(|p| fs::read_to_string(p).ok())
+            .and_then(|s| toml::from_str(&s).ok())
+            .unwrap_or_default()
+    }
+
+    pub fn save(&self) -> Result<()> {
+        let path = Self::path().ok_or_else(|| anyhow!("cannot determine config directory"))?;
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        fs::write(&path, toml::to_string_pretty(self)?)?;
+        Ok(())
+    }
+
+    pub fn for_device(&self, serial: u32) -> DeviceNames {
+        self.device
+            .get(&serial.to_string())
+            .cloned()
+            .unwrap_or_default()
+    }
+
+    pub fn for_device_mut(&mut self, serial: u32) -> &mut DeviceNames {
+        self.device.entry(serial.to_string()).or_default()
+    }
+
+    pub fn validate_name(name: &str) -> Result<()> {
+        if name.parse::<usize>().is_ok() {
+            return Err(anyhow!("name cannot be a number (would shadow an index)"));
+        }
+        Ok(())
+    }
+}
+
+fn resolve(map: &IndexMap<String, usize>, kind: &str, name_or_index: &str) -> Result<usize> {
+    if let Ok(idx) = name_or_index.parse::<usize>() {
+        return Ok(idx);
+    }
+    map.get(name_or_index)
+        .copied()
+        .ok_or_else(|| anyhow!("unknown {} name: '{}'", kind, name_or_index))
+}
+
+fn label_for(map: &IndexMap<String, usize>, index: usize) -> String {
+    map.iter()
+        .find(|(_, &idx)| idx == index)
+        .map(|(name, _)| name.clone())
+        .unwrap_or_else(|| index.to_string())
+}
+
+impl DeviceNames {
+    pub fn resolve_input(&self, name_or_index: &str) -> Result<usize> {
+        resolve(&self.inputs, "input", name_or_index)
+    }
+
+    pub fn resolve_output(&self, name_or_index: &str) -> Result<usize> {
+        resolve(&self.outputs, "output", name_or_index)
+    }
+
+    pub fn label_for_input(&self, index: usize) -> String {
+        label_for(&self.inputs, index)
+    }
+
+    pub fn label_for_output(&self, index: usize) -> String {
+        label_for(&self.outputs, index)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_device_names() -> DeviceNames {
+        let mut dn = DeviceNames::default();
+        dn.inputs.insert("left".into(), 0);
+        dn.inputs.insert("right".into(), 1);
+        dn.outputs.insert("left".into(), 0);
+        dn.outputs.insert("right".into(), 1);
+        dn.outputs.insert("sub_left".into(), 2);
+        dn.outputs.insert("main_l".into(), 0);
+        dn
+    }
+
+    #[test]
+    fn resolve_by_index() {
+        let dn = sample_device_names();
+        assert_eq!(dn.resolve_input("0").unwrap(), 0);
+        assert_eq!(dn.resolve_output("3").unwrap(), 3);
+    }
+
+    #[test]
+    fn resolve_by_name() {
+        let dn = sample_device_names();
+        assert_eq!(dn.resolve_input("left").unwrap(), 0);
+        assert_eq!(dn.resolve_output("sub_left").unwrap(), 2);
+    }
+
+    #[test]
+    fn resolve_unknown_name() {
+        let dn = sample_device_names();
+        assert!(dn.resolve_input("bogus").is_err());
+        assert!(dn.resolve_output("bogus").is_err());
+    }
+
+    #[test]
+    fn validate_rejects_numeric() {
+        assert!(NamesConfig::validate_name("3").is_err());
+        assert!(NamesConfig::validate_name("42").is_err());
+    }
+
+    #[test]
+    fn validate_accepts_text() {
+        assert!(NamesConfig::validate_name("left").is_ok());
+        assert!(NamesConfig::validate_name("sub_3").is_ok());
+    }
+
+    #[test]
+    fn label_uses_first_in_order() {
+        let dn = sample_device_names();
+        assert_eq!(dn.label_for_output(0), "left");
+    }
+
+    #[test]
+    fn label_falls_back_to_index() {
+        let dn = sample_device_names();
+        assert_eq!(dn.label_for_output(9), "9");
+        assert_eq!(dn.label_for_input(5), "5");
+    }
+
+    #[test]
+    fn for_device_returns_empty_for_unknown() {
+        let cfg = NamesConfig::default();
+        let dn = cfg.for_device(999999);
+        assert!(dn.inputs.is_empty());
+        assert!(dn.outputs.is_empty());
+    }
+
+    #[test]
+    fn for_device_mut_creates_entry() {
+        let mut cfg = NamesConfig::default();
+        cfg.for_device_mut(123).inputs.insert("left".into(), 0);
+        assert_eq!(cfg.for_device(123).resolve_input("left").unwrap(), 0);
+    }
+}


### PR DESCRIPTION
## Summary

Adds a `name` subcommand to assign human-readable names to input/output channels, stored per-device in `~/.config/minidsp/names.toml`.

## Usage

```bash
# Assign names (device must be connected)
minidsp name output 0 left
minidsp name output 1 right
minidsp name output 2 sub_left
minidsp name output 3 sub_right

# Use names anywhere an index is accepted
minidsp output left gain -- -10
minidsp input left routing right gain -- -3

# Status shows names
minidsp status
# Output levels: left: -67.9, right: -71.6, sub_left: -120.0, sub_right: -120.0

# List all configured names (works offline)
minidsp name list
```

## Design decisions

- **Per-device storage**: names keyed by serial number (`[device.902106.outputs]`)
- **Backwards compatible**: numeric indices still work everywhere
- **No new config for existing users**: names are purely optional
- **IndexMap** for config-file-order priority when multiple aliases exist
- **Validation**: pure-numeric names rejected to avoid shadowing indices
- **JSON output unaffected**: only text status display shows names

## Changes

- `minidsp/src/bin/minidsp/names.rs` — new module (config load/save/resolve + tests)
- `minidsp/src/bin/minidsp/main.rs` — NameCommand enum, String indices, dispatch
- `minidsp/src/bin/minidsp/handlers.rs` — name resolution, status display
- `minidsp/Cargo.toml` — +`dirs`, `indexmap`, `toml`
- `docs/src/cli/names.md` — documentation

## Testing

- 10 unit tests covering resolve, validation, labels, per-device lookup
- Tested on MiniDSP Flex (serial 902106)