### PR TITLE
Return an error instead of panicking on an out-of-range routing output index

### DIFF
--- a/minidsp/src/lib.rs
+++ b/minidsp/src/lib.rs
@@ -373,6 +373,9 @@ pub struct Input<'a> {
 impl Input<'_> {
     /// Sets whether this input is routed to the given output
     pub async fn set_output_enable(&self, output_index: usize, value: bool) -> Result<()> {
+        if output_index >= self.spec.routing.len() {
+            return Err(MiniDSPError::OutOfRange);
+        }
         let dialect = self.dsp.dialect();
         let addr = dialect.addr(self.spec.routing[output_index].enable);
         let value = dialect.mute(!value);
@@ -382,6 +385,9 @@ impl Input<'_> {
 
     /// Sets the routing matrix gain for this [input, output_index] pair
     pub async fn set_output_gain(&self, output_index: usize, gain: Gain) -> Result<()> {
+        if output_index >= self.spec.routing.len() {
+            return Err(MiniDSPError::OutOfRange);
+        }
         let addr = self.spec.routing[output_index]
             .gain
             .ok_or(MiniDSPError::NoSuchPeripheral)?;


### PR DESCRIPTION
Fixes #770. `Input::set_output_enable` and `set_output_gain` index `self.spec.routing[output_index]` directly, so passing an output index past the device's routing matrix (e.g. `input 0 routing 8` on an 8-entry device) panics with "index out of bounds" instead of reporting an error. This adds the same `output_index >= routing.len()` guard returning `MiniDSPError::OutOfRange` that `MiniDSP::input`/`output` already use for their channel indices.

I didn't add a unit test for this path because constructing an `Input` requires a live `MiniDSP`/`Client` and the mock transport's inner `Transport` field is private, so there's no lightweight in-crate way to build one; happy to add a test if you can point me at the preferred harness.