### PR TITLE
Detect the Flex DL and correct its internal sampling rate

### DIFF
--- a/devtools/src/codegen/flexdl/mod.rs
+++ b/devtools/src/codegen/flexdl/mod.rs
@@ -78,7 +78,7 @@ pub fn device() -> Device {
         inputs: (0..2).map(input).collect(),
         outputs: (0..4).map(output).collect(),
         fir_max_taps: 4096,
-        internal_sampling_rate: 4800,
+        internal_sampling_rate: 48000,
         ..Default::default()
     }
 }

--- a/protocol/src/device/flexdl.rs
+++ b/protocol/src/device/flexdl.rs
@@ -436,7 +436,7 @@ pub const DEVICE: Device = Device {
         },
     ],
     fir_max_taps: 4096,
-    internal_sampling_rate: 4800,
+    internal_sampling_rate: 48000,
     dialect: Dialect {
         addr_encoding: AddrEncoding::AddrLen3,
         float_encoding: FloatEncoding::Float32LE,

--- a/protocol/src/device/probe.rs
+++ b/protocol/src/device/probe.rs
@@ -41,6 +41,8 @@ pub enum DeviceKind {
     M2x4,
     #[cfg(feature = "device_flex")]
     Flex,
+    #[cfg(feature = "device_flexdl")]
+    FlexDl,
     #[cfg(feature = "device_flexhtx")]
     FlexHtx,
 }
@@ -76,6 +78,8 @@ pub fn probe_kind(device_info: &DeviceInfo) -> DeviceKind {
         (2, 22) => M2x4,
         #[cfg(feature = "device_flex")]
         (27, 100) => Flex,
+        #[cfg(feature = "device_flexdl")]
+        (27, 101) => FlexDl,
 
         #[cfg(feature = "device_flexhtx")]
         (32, 115) => FlexHtx, //get from `minidsp probe`
@@ -121,6 +125,9 @@ pub fn by_kind(kind: DeviceKind) -> &'static super::Device {
 
         #[cfg(feature = "device_flex")]
         Flex => &super::flex::DEVICE,
+
+        #[cfg(feature = "device_flexdl")]
+        FlexDl => &super::flexdl::DEVICE,
 
         #[cfg(feature = "device_flexhtx")]
         FlexHtx => &super::flexhtx::DEVICE,


### PR DESCRIPTION
## Background

`protocol/src/device/flexdl.rs` has been in the tree since the `flexdrc -> flexdl` rename, but nothing can resolve to it: there is no `FlexDl` variant in `DeviceKind`, no arm in `probe_kind()`, and none in `by_kind()`. As a result `--force-kind flexdl` is also rejected during argument parsing, so the profile is unreachable from every direction.

The effect on a Flex DL is that it falls through to `Generic`. Master volume, source, mute, preset and Dirac still work, since those live at fixed addresses, but meters, PEQ, crossovers, delay and FIR are unavailable and `status` prints empty level lists.

## Changes

**1. Wire up the profile.** Adds `DeviceKind::FlexDl`, the `(27, 101)` arm in `probe_kind()`, and the corresponding `by_kind()` arm.

The `dsp_version` key is the `<dspversion>` declared by the profile's own source config, which is consistent with how the neighbouring entries line up:

| profile | `<dspversion>` in its config.xml | probe entry |
| --- | --- | --- |
| `flex` | 100 | `(27, 100)` |
| `flexdl` | 101 | added here |
| `flexhtx` | 115 | `(32, 115)` |

**2. Fix `internal_sampling_rate`.** It was `4800`, an order of magnitude below every other profile in the repo (all 48000 or 96000). It converts milliseconds to samples in `set_delay()` (`minidsp/src/lib.rs:425`), so output delays landed 10x short. It also scales the range check immediately below that conversion, and is passed to the WAV reader when loading FIR taps.

Rather than assume the intended value, it is derived from the plugin config the profile is generated from. That config carries Linkwitz-Riley crossover coefficients alongside their stated design frequencies, which is enough to solve the bilinear transform for fs:

| filter | design freq | solved fs | DC gain |
| --- | --- | --- | --- |
| `BPF_1_1` LRLPF_8 s1 | 1000 Hz | 48000.000 Hz | 1.000000 |
| `BPF_1_1` LRLPF_8 s2 | 1000 Hz | 48000.000 Hz | 1.000000 |
| `BPF_2_1` LRLPF_8 s1 | 5000 Hz | 48000.000 Hz | 1.000000 |
| `BPF_2_1` LRLPF_8 s2 | 5000 Hz | 48000.000 Hz | 1.000000 |

Both the codegen spec and its generated output are updated. Re-running codegen reproduces the committed file byte for byte.

## Verification

Tested against a Flex DL reporting `hw_id: 27, dsp_version: 101`.

Before:

```
0: Found Generic with serial 903660 at usb:...?vid=2752&pid=0044 [hw_id: 27, dsp_version: 101]
MasterStatus { preset: 0, source: Usb, volume: Gain(-0.0), mute: false, dirac: false }
Input levels:
Output levels:
```

After:

```
0: Found Flex DRC with serial 903660 at usb:...?vid=2752&pid=0044 [hw_id: 27, dsp_version: 101]
MasterStatus { preset: 0, source: Usb, volume: Gain(-0.0), mute: false, dirac: false }
Input levels: -120.0, -120.0
Output levels: -120.0, -120.0, -120.0, -120.0
```

Six meters at the silence floor with nothing playing, and the 2-in/4-out topology matches the profile. For contrast, forcing the plain `flex` profile on the same unit returns `0.0` on all six, since its meters live at different symbols (`Meter02_C1_*` / `Meter10_C1_*` versus `Meter_D_In_*` / `Meter_Out_*`).

Also run:

- `cargo test --workspace` passes
- `cargo fmt --all --check` clean
- `cargo clippy --workspace --all-targets` introduces no new warnings
- Regenerating all 13 device profiles and diffing against the tree shows only the intended `flexdl` change

## Not verified

I have a single unit, so I cannot confirm whether other Flex DL firmware revisions report a different `dsp_version`. If they do, this entry will need widening in the same way `(1, _)`, `(4, _)` and `(14, _)` are handled elsewhere in the table.

The `set_delay()` range check is left alone here. It caps at 8000 samples with a message stating "[0, 80] ms", which is only accurate at 96 kHz; at 48 kHz it permits ~166 ms. That predates this change and affects the other 48 kHz profiles equally, so it seemed better left to a separate PR.
